### PR TITLE
Remove state_class from device wrapper

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/base.py
+++ b/src/tuya_device_handlers/device_wrapper/base.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..helpers.homeassistant import TuyaSensorStateClass
-
 if TYPE_CHECKING:
     from tuya_sharing import CustomerDevice  # type: ignore[import-untyped]
 
@@ -15,7 +13,6 @@ class DeviceWrapper[T]:
 
     native_unit: str | None = None
     suggested_unit: str | None = None
-    state_class: TuyaSensorStateClass | None = None
 
     max_value: float
     min_value: float

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ..helpers.homeassistant import TuyaSensorStateClass
 from ..raw_data_model import ElectricityData
 from .base import DeviceWrapper
 from .common import (
@@ -60,7 +59,6 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
 
     _accumulated_value: float = 0
     _last_dp_timestamp: int | None = None
-    state_class = TuyaSensorStateClass.TOTAL_INCREASING
 
     def skip_update(
         self,

--- a/tests/device_wrapper/__snapshots__/test_sensor.ambr
+++ b/tests/device_wrapper/__snapshots__/test_sensor.ambr
@@ -3,7 +3,6 @@
   dict({
     'native_unit': '%',
     'state': 0,
-    'state_class': <TuyaSensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     'suggested_unit': None,
   })
 # ---
@@ -11,7 +10,6 @@
   dict({
     'native_unit': 'A',
     'state': 599.552,
-    'state_class': None,
     'suggested_unit': None,
   })
 # ---
@@ -19,7 +17,6 @@
   dict({
     'native_unit': 'mA',
     'state': 72,
-    'state_class': None,
     'suggested_unit': 'A',
   })
 # ---
@@ -27,7 +24,6 @@
   dict({
     'native_unit': 'kW',
     'state': 6.912,
-    'state_class': None,
     'suggested_unit': None,
   })
 # ---
@@ -35,7 +31,6 @@
   dict({
     'native_unit': 'W',
     'state': 8,
-    'state_class': None,
     'suggested_unit': 'kW',
   })
 # ---
@@ -43,7 +38,6 @@
   dict({
     'native_unit': 'V',
     'state': 52.7,
-    'state_class': None,
     'suggested_unit': None,
   })
 # ---
@@ -51,7 +45,6 @@
   dict({
     'native_unit': 'V',
     'state': 234.1,
-    'state_class': None,
     'suggested_unit': None,
   })
 # ---
@@ -77,7 +70,6 @@
       'north_north_west',
     ]),
     'state': 22.5,
-    'state_class': None,
     'suggested_unit': None,
   })
 # ---

--- a/tests/device_wrapper/test_sensor.py
+++ b/tests/device_wrapper/test_sensor.py
@@ -20,7 +20,6 @@ from tuya_device_handlers.device_wrapper.sensor import (
     ElectricityVoltageRawWrapper,
     WindDirectionEnumWrapper,
 )
-from tuya_device_handlers.helpers.homeassistant import TuyaSensorStateClass
 
 from . import send_wrapper_update
 
@@ -34,7 +33,6 @@ def _snapshot_sensor(
     expected = {
         "native_unit": wrapper.native_unit,
         "state": wrapper.read_device_status(mock_device),
-        "state_class": wrapper.state_class,
         "suggested_unit": wrapper.suggested_unit,
     }
     for key in ("options",):
@@ -202,7 +200,6 @@ def test_delta_sensor(
 
     assert wrapper
     wrapper.initialize(mock_device)
-    assert wrapper.state_class == TuyaSensorStateClass.TOTAL_INCREASING
     assert wrapper.read_device_status(mock_device) == 0
 
     # Send delta update


### PR DESCRIPTION
State class is a Home Assistant implementation detail.
Based on feedback in https://github.com/home-assistant/core/pull/158791