### PR TITLE
Refactor skip_update

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/base.py
+++ b/src/tuya_device_handlers/device_wrapper/base.py
@@ -30,7 +30,7 @@ class DeviceWrapper[T]:
     def skip_update(
         self,
         device: CustomerDevice,
-        updated_status_properties: list[str] | None,
+        updated_status_properties: list[str],
         dp_timestamps: dict[str, int] | None = None,
     ) -> bool:
         """Determine if the wrapper should skip an update.

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -56,7 +56,7 @@ class DPCodeWrapper(DeviceWrapper[Any]):
     def skip_update(
         self,
         device: CustomerDevice,
-        updated_status_properties: list[str] | None,
+        updated_status_properties: list[str],
         dp_timestamps: dict[str, int] | None = None,
     ) -> bool:
         """Determine if the wrapper should skip an update.
@@ -64,10 +64,7 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         By default, skip if updated_status_properties is not given or
         does not include this dpcode.
         """
-        return (
-            updated_status_properties is None
-            or self.dpcode not in updated_status_properties
-        )
+        return self.dpcode not in updated_status_properties
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
         """Read and process raw value against this type information.

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -63,7 +63,7 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
     def skip_update(
         self,
         device: CustomerDevice,
-        updated_status_properties: list[str] | None,
+        updated_status_properties: list[str],
         dp_timestamps: dict[str, int] | None = None,
     ) -> bool:
         """Override skip_update to process delta updates.

--- a/tests/device_wrapper/test_base.py
+++ b/tests/device_wrapper/test_base.py
@@ -10,8 +10,8 @@ def test_skip_update(mock_device: CustomerDevice) -> None:
     wrapper = DeviceWrapper[str]()
 
     assert wrapper
-    assert wrapper.skip_update(mock_device, None, None) is True
+    assert wrapper.skip_update(mock_device, [], None) is True
     assert wrapper.skip_update(mock_device, ["a", "b", "c"], {}) is True
     # Ensure compatibility when dp_timestamps is not passed up
-    assert wrapper.skip_update(mock_device, None) is True
+    assert wrapper.skip_update(mock_device, []) is True
     assert wrapper.skip_update(mock_device, ["a", "b", "c"]) is True

--- a/tests/device_wrapper/test_common.py
+++ b/tests/device_wrapper/test_common.py
@@ -212,13 +212,13 @@ def test_skip_update(mock_device: CustomerDevice) -> None:
     wrapper = DPCodeIntegerWrapper.find_dpcode(mock_device, "demo_integer")
 
     assert wrapper
-    assert wrapper.skip_update(mock_device, None, None) is True
+    assert wrapper.skip_update(mock_device, [], None) is True
     assert wrapper.skip_update(mock_device, ["a", "b", "c"], {}) is True
     assert (
         wrapper.skip_update(mock_device, ["a", "demo_integer", "c"], {})
         is False
     )
     # Ensure compatibility when dp_timestamps is not passed up
-    assert wrapper.skip_update(mock_device, None) is True
+    assert wrapper.skip_update(mock_device, []) is True
     assert wrapper.skip_update(mock_device, ["a", "b", "c"]) is True
     assert wrapper.skip_update(mock_device, ["a", "demo_integer", "c"]) is False


### PR DESCRIPTION
Based on https://github.com/home-assistant/core/pull/163431

`skip_update` is only called if `updated_status_properties` is not `None`