### PR TITLE
Improve type hints in wrapper classes

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/binary_sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/binary_sensor.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Self
 
 from ..type_information import BitmapTypeInformation
-from .base import DeviceWrapper
 from .common import DPCodeBitmapWrapper
 
 if TYPE_CHECKING:
     from tuya_sharing import CustomerDevice  # type: ignore[import-untyped]
 
 
-class DPCodeBitmapBitWrapper(DPCodeBitmapWrapper, DeviceWrapper[bool]):
+class DPCodeBitmapBitWrapper(DPCodeBitmapWrapper[bool]):
     """Simple wrapper for a specific bit in bitmap values."""
 
     def __init__(

--- a/src/tuya_device_handlers/device_wrapper/binary_sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/binary_sensor.py
@@ -24,7 +24,7 @@ class DPCodeBitmapBitWrapper(DPCodeBitmapWrapper, DeviceWrapper[bool]):
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super().read_device_status(device)) is None:
+        if (raw_value := self._read_dpcode_value(device)) is None:
             return None
         return (raw_value & (1 << self._mask)) != 0
 

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -180,9 +180,11 @@ class DPCodeBooleanWrapper[T = bool](
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> Any:
+        self, device: CustomerDevice, value: T
+    ) -> bool:
         """Convert a Home Assistant value back to a raw device value."""
+        if TYPE_CHECKING:
+            assert isinstance(value, bool)
         if value in (True, False):
             return value
         # Currently only called with boolean values
@@ -227,9 +229,11 @@ class DPCodeEnumWrapper[T = str](
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> Any:
+        self, device: CustomerDevice, value: T
+    ) -> str:
         """Convert a Home Assistant value back to a raw device value."""
+        if TYPE_CHECKING:
+            assert isinstance(value, str)
         if value in self.type_information.range:
             return value
         # Guarded by select option validation
@@ -284,9 +288,11 @@ class DPCodeIntegerWrapper[T = float](
         return self.type_information.scale_value(raw_value)
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> Any:
+        self, device: CustomerDevice, value: T
+    ) -> int:
         """Convert a Home Assistant value back to a raw device value."""
+        if TYPE_CHECKING:
+            assert isinstance(value, float)
         new_value = self.type_information.scale_value_back(value)
         if self.type_information.min <= new_value <= self.type_information.max:
             return new_value

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -305,7 +305,7 @@ class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
-        return json.loads(raw_value)
+        return json.loads(raw_value)  # type: ignore[no-any-return]
 
 
 class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -295,7 +295,7 @@ class DPCodeIntegerWrapper(
 
 
 class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
-    """Base wrapper for JsonTypeInformation values."""
+    """Simple wrapper for JsonTypeInformation values."""
 
     _DPTYPE = JsonTypeInformation
 

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -180,7 +180,7 @@ class DPCodeBooleanWrapper[T = bool](
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: T
+        self, device: CustomerDevice, value: Any
     ) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
         if value in (True, False):

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -42,7 +42,7 @@ def _should_log_warning(device_id: str, warning_key: str) -> bool:
     return True
 
 
-class DPCodeWrapper(DeviceWrapper[Any]):
+class DPCodeWrapper[T](DeviceWrapper[T]):
     """Base device wrapper for a single DPCode.
 
     Used as a common interface for referring to a DPCode, and
@@ -66,7 +66,7 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         """
         return self.dpcode not in updated_status_properties
 
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
+    def read_device_status(self, device: CustomerDevice) -> T | None:
         """Read device status and convert to a Home Assistant value."""
         return self._read_dpcode_value(device)
 
@@ -79,7 +79,7 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         return device.status.get(self.dpcode)
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
+        self, device: CustomerDevice, value: T
     ) -> Any:
         """Convert display value back to a raw device value.
 
@@ -89,7 +89,7 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         raise NotImplementedError
 
     def get_update_commands(
-        self, device: CustomerDevice, value: Any
+        self, device: CustomerDevice, value: T
     ) -> list[dict[str, Any]]:
         """Get the update commands for the dpcode.
 
@@ -103,8 +103,8 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         ]
 
 
-class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation](
-    DPCodeWrapper
+class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation, T](
+    DPCodeWrapper[T]
 ):
     """Base DPCode wrapper with Type Information."""
 
@@ -135,7 +135,9 @@ class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation](
         return None
 
 
-class DPCodeBitmapWrapper(DPCodeTypeInformationWrapper[BitmapTypeInformation]):
+class DPCodeBitmapWrapper[T = int](
+    DPCodeTypeInformationWrapper[BitmapTypeInformation, T]
+):
     """Simple wrapper for BitmapTypeInformation values."""
 
     _DPTYPE = BitmapTypeInformation
@@ -149,8 +151,8 @@ class DPCodeBitmapWrapper(DPCodeTypeInformationWrapper[BitmapTypeInformation]):
         return raw_value
 
 
-class DPCodeBooleanWrapper(
-    DPCodeTypeInformationWrapper[BooleanTypeInformation]
+class DPCodeBooleanWrapper[T = bool](
+    DPCodeTypeInformationWrapper[BooleanTypeInformation, T]
 ):
     """Simple wrapper for BooleanTypeInformation values."""
 
@@ -178,8 +180,8 @@ class DPCodeBooleanWrapper(
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: bool
-    ) -> bool | None:
+        self, device: CustomerDevice, value: T
+    ) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
         if value in (True, False):
             return value
@@ -188,7 +190,9 @@ class DPCodeBooleanWrapper(
         raise SetValueOutOfRangeError(f"Invalid boolean value `{value}`")
 
 
-class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
+class DPCodeEnumWrapper[T = str](
+    DPCodeTypeInformationWrapper[EnumTypeInformation, T]
+):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
@@ -223,8 +227,8 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: str
-    ) -> str | None:
+        self, device: CustomerDevice, value: Any
+    ) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
         if value in self.type_information.range:
             return value
@@ -235,8 +239,8 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         )
 
 
-class DPCodeIntegerWrapper(
-    DPCodeTypeInformationWrapper[IntegerTypeInformation]
+class DPCodeIntegerWrapper[T = float](
+    DPCodeTypeInformationWrapper[IntegerTypeInformation, T]
 ):
     """Simple wrapper for IntegerTypeInformation values."""
 
@@ -280,8 +284,8 @@ class DPCodeIntegerWrapper(
         return self.type_information.scale_value(raw_value)
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: float
-    ) -> int:
+        self, device: CustomerDevice, value: Any
+    ) -> Any:
         """Convert a Home Assistant value back to a raw device value."""
         new_value = self.type_information.scale_value_back(value)
         if self.type_information.min <= new_value <= self.type_information.max:
@@ -294,7 +298,9 @@ class DPCodeIntegerWrapper(
         )
 
 
-class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
+class DPCodeJsonWrapper[T = dict[str, Any]](
+    DPCodeTypeInformationWrapper[JsonTypeInformation, T]
+):
     """Simple wrapper for JsonTypeInformation values."""
 
     _DPTYPE = JsonTypeInformation
@@ -308,7 +314,9 @@ class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
         return json.loads(raw_value)  # type: ignore[no-any-return]
 
 
-class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
+class DPCodeRawWrapper[T = bytes](
+    DPCodeTypeInformationWrapper[RawTypeInformation, T]
+):
     """Simple wrapper for RawTypeInformation values."""
 
     _DPTYPE = RawTypeInformation
@@ -320,7 +328,9 @@ class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
         return base64.b64decode(raw_value)
 
 
-class DPCodeStringWrapper(DPCodeTypeInformationWrapper[StringTypeInformation]):
+class DPCodeStringWrapper[T = str](
+    DPCodeTypeInformationWrapper[StringTypeInformation, T]
+):
     """Simple wrapper for StringTypeInformation values."""
 
     _DPTYPE = StringTypeInformation

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -184,7 +184,7 @@ class DPCodeBooleanWrapper(
         raise SetValueOutOfRangeError(f"Invalid boolean value `{value}`")
 
 
-class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
+class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
     """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
@@ -197,7 +197,7 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         super().__init__(dpcode, type_information)
         self.options = type_information.range
 
-    def read_device_status(self, device: CustomerDevice) -> str | None:
+    def _read_device_status(self, device: CustomerDevice) -> str | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
@@ -218,6 +218,10 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
             return None
         return raw_value  # type: ignore[no-any-return]
 
+    def read_device_status(self, device: CustomerDevice) -> Any | None:
+        """Read and process raw value against this type information."""
+        raise NotImplementedError
+
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: str
     ) -> str | None:
@@ -229,6 +233,14 @@ class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         raise SetValueOutOfRangeError(
             f"Enum value `{value}` out of range: {self.type_information.range}"
         )
+
+
+class DPCodeEnumWrapper(DPCodeEnumBaseWrapper, DeviceWrapper[str]):
+    """Simple wrapper for EnumTypeInformation values."""
+
+    def read_device_status(self, device: CustomerDevice) -> str | None:
+        """Read and process raw value against this type information."""
+        return super()._read_device_status(device)
 
 
 class DPCodeIntegerWrapper(
@@ -290,12 +302,12 @@ class DPCodeIntegerWrapper(
         )
 
 
-class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
+class DPCodeJsonBaseWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
     """Simple wrapper for JsonTypeInformation values."""
 
     _DPTYPE = JsonTypeInformation
 
-    def read_device_status(
+    def _read_device_status(
         self, device: CustomerDevice
     ) -> dict[str, Any] | None:
         """Read and process raw value against this type information."""
@@ -303,17 +315,43 @@ class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
             return None
         return json.loads(raw_value)  # type: ignore[no-any-return]
 
+    def read_device_status(self, device: CustomerDevice) -> Any | None:
+        """Read and process raw value against this type information."""
+        raise NotImplementedError
 
-class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
+
+class DPCodeJsonWrapper(DPCodeJsonBaseWrapper, DeviceWrapper[dict[str, Any]]):
+    """Simple wrapper for JsonTypeInformation values."""
+
+    def read_device_status(
+        self, device: CustomerDevice
+    ) -> dict[str, Any] | None:
+        """Read and process raw value against this type information."""
+        return super()._read_device_status(device)
+
+
+class DPCodeRawBaseWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
     """Simple wrapper for RawTypeInformation values."""
 
     _DPTYPE = RawTypeInformation
 
-    def read_device_status(self, device: CustomerDevice) -> bytes | None:
+    def _read_device_status(self, device: CustomerDevice) -> bytes | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         return base64.b64decode(raw_value)
+
+    def read_device_status(self, device: CustomerDevice) -> Any | None:
+        """Read and process raw value against this type information."""
+        raise NotImplementedError
+
+
+class DPCodeRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[bytes]):
+    """Simple wrapper for RawTypeInformation values."""
+
+    def read_device_status(self, device: CustomerDevice) -> bytes | None:
+        """Read and process raw value against this type information."""
+        return super()._read_device_status(device)
 
 
 class DPCodeStringWrapper(DPCodeTypeInformationWrapper[StringTypeInformation]):

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -184,6 +184,9 @@ class DPCodeBooleanWrapper[T = bool](
     ) -> bool:
         """Convert a Home Assistant value back to a raw device value."""
         if value in (True, False):
+            if TYPE_CHECKING:
+                # mypy doesn't infer that if it's in a tuple of bools it's a bool
+                assert isinstance(value, bool)
             return value
         # Currently only called with boolean values
         # Safety net in case of future changes
@@ -231,6 +234,9 @@ class DPCodeEnumWrapper[T = str](
     ) -> str:
         """Convert a Home Assistant value back to a raw device value."""
         if value in self.type_information.range:
+            if TYPE_CHECKING:
+                # mypy doesn't infer that if it's in a list of strings it's a string
+                assert isinstance(value, str)
             return value
         # Guarded by select option validation
         # Safety net in case of future changes

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -67,10 +67,14 @@ class DPCodeWrapper(DeviceWrapper[Any]):
         return self.dpcode not in updated_status_properties
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read and process raw value against this type information.
+        """Read device status and convert to a Home Assistant value."""
+        return self._read_dpcode_value(device)
 
-        Base implementation does no validation, subclasses may override to provide
-        specific validation.
+    def _read_dpcode_value(self, device: CustomerDevice) -> Any | None:
+        """Read the DPCode value.
+
+        Base implementation returns the raw value, subclasses may override to provide
+        specific conversion or validation.
         """
         return device.status.get(self.dpcode)
 
@@ -131,31 +135,18 @@ class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation](
         return None
 
 
-class DPCodeBitmapBaseWrapper(
-    DPCodeTypeInformationWrapper[BitmapTypeInformation]
-):
-    """Base wrapper for BitmapTypeInformation values.
-
-    Provides typed `_read_device_status`, and `read_device_status` should be
-    implemented in subclass."""
+class DPCodeBitmapWrapper(DPCodeTypeInformationWrapper[BitmapTypeInformation]):
+    """Simple wrapper for BitmapTypeInformation values."""
 
     _DPTYPE = BitmapTypeInformation
 
-    def _read_device_status(self, device: CustomerDevice) -> int | None:
+    def _read_dpcode_value(self, device: CustomerDevice) -> int | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         if TYPE_CHECKING:
             assert isinstance(raw_value, int)
         return raw_value
-
-
-class DPCodeBitmapWrapper(DPCodeBitmapBaseWrapper, DeviceWrapper[int]):
-    """Simple wrapper for BitmapTypeInformation values."""
-
-    def read_device_status(self, device: CustomerDevice) -> int | None:
-        """Read and process raw value against this type information."""
-        return super()._read_device_status(device)
 
 
 class DPCodeBooleanWrapper(
@@ -165,7 +156,7 @@ class DPCodeBooleanWrapper(
 
     _DPTYPE = BooleanTypeInformation
 
-    def read_device_status(self, device: CustomerDevice) -> bool | None:
+    def _read_dpcode_value(self, device: CustomerDevice) -> bool | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
@@ -197,12 +188,8 @@ class DPCodeBooleanWrapper(
         raise SetValueOutOfRangeError(f"Invalid boolean value `{value}`")
 
 
-class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
-    """Base wrapper for EnumTypeInformation values.
-
-    Provides typed `_read_device_status`, and `read_device_status` should be
-    implemented in subclass.
-    """
+class DPCodeEnumWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
+    """Simple wrapper for EnumTypeInformation values."""
 
     _DPTYPE = EnumTypeInformation
     options: list[str]
@@ -214,7 +201,7 @@ class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         super().__init__(dpcode, type_information)
         self.options = type_information.range
 
-    def _read_device_status(self, device: CustomerDevice) -> str | None:
+    def _read_dpcode_value(self, device: CustomerDevice) -> str | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
@@ -235,10 +222,6 @@ class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
             return None
         return raw_value  # type: ignore[no-any-return]
 
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read and process raw value against this type information."""
-        raise NotImplementedError
-
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: str
     ) -> str | None:
@@ -250,14 +233,6 @@ class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
         raise SetValueOutOfRangeError(
             f"Enum value `{value}` out of range: {self.type_information.range}"
         )
-
-
-class DPCodeEnumWrapper(DPCodeEnumBaseWrapper, DeviceWrapper[str]):
-    """Simple wrapper for EnumTypeInformation values."""
-
-    def read_device_status(self, device: CustomerDevice) -> str | None:
-        """Read and process raw value against this type information."""
-        return super()._read_device_status(device)
 
 
 class DPCodeIntegerWrapper(
@@ -279,7 +254,7 @@ class DPCodeIntegerWrapper(
             type_information.step
         )
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:
+    def _read_dpcode_value(self, device: CustomerDevice) -> float | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
@@ -319,63 +294,30 @@ class DPCodeIntegerWrapper(
         )
 
 
-class DPCodeJsonBaseWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
-    """Base wrapper for JsonTypeInformation values.
-
-    Provides typed `_read_device_status`, and `read_device_status` should be
-    implemented in subclass."""
+class DPCodeJsonWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
+    """Base wrapper for JsonTypeInformation values."""
 
     _DPTYPE = JsonTypeInformation
 
-    def _read_device_status(
+    def _read_dpcode_value(
         self, device: CustomerDevice
     ) -> dict[str, Any] | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
-        return json.loads(raw_value)  # type: ignore[no-any-return]
-
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read and process raw value against this type information."""
-        raise NotImplementedError
+        return json.loads(raw_value)
 
 
-class DPCodeJsonWrapper(DPCodeJsonBaseWrapper, DeviceWrapper[dict[str, Any]]):
-    """Simple wrapper for JsonTypeInformation values."""
-
-    def read_device_status(
-        self, device: CustomerDevice
-    ) -> dict[str, Any] | None:
-        """Read and process raw value against this type information."""
-        return super()._read_device_status(device)
-
-
-class DPCodeRawBaseWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
-    """Base wrapper for RawTypeInformation values.
-
-    Provides typed `_read_device_status`, and `read_device_status` should be
-    implemented in subclass.
-    """
+class DPCodeRawWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
+    """Simple wrapper for RawTypeInformation values."""
 
     _DPTYPE = RawTypeInformation
 
-    def _read_device_status(self, device: CustomerDevice) -> bytes | None:
+    def _read_dpcode_value(self, device: CustomerDevice) -> bytes | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         return base64.b64decode(raw_value)
-
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
-        """Read and process raw value against this type information."""
-        raise NotImplementedError
-
-
-class DPCodeRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[bytes]):
-    """Simple wrapper for RawTypeInformation values."""
-
-    def read_device_status(self, device: CustomerDevice) -> bytes | None:
-        """Read and process raw value against this type information."""
-        return super()._read_device_status(device)
 
 
 class DPCodeStringWrapper(DPCodeTypeInformationWrapper[StringTypeInformation]):

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -131,18 +131,31 @@ class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation](
         return None
 
 
-class DPCodeBitmapWrapper(DPCodeTypeInformationWrapper[BitmapTypeInformation]):
-    """Simple wrapper for BitmapTypeInformation values."""
+class DPCodeBitmapBaseWrapper(
+    DPCodeTypeInformationWrapper[BitmapTypeInformation]
+):
+    """Base wrapper for BitmapTypeInformation values.
+
+    Provides typed `_read_device_status`, and `read_device_status` should be
+    implemented in subclass."""
 
     _DPTYPE = BitmapTypeInformation
 
-    def read_device_status(self, device: CustomerDevice) -> int | None:
+    def _read_device_status(self, device: CustomerDevice) -> int | None:
         """Read and process raw value against this type information."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         if TYPE_CHECKING:
             assert isinstance(raw_value, int)
         return raw_value
+
+
+class DPCodeBitmapWrapper(DPCodeBitmapBaseWrapper, DeviceWrapper[int]):
+    """Simple wrapper for BitmapTypeInformation values."""
+
+    def read_device_status(self, device: CustomerDevice) -> int | None:
+        """Read and process raw value against this type information."""
+        return super()._read_device_status(device)
 
 
 class DPCodeBooleanWrapper(

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -79,7 +79,7 @@ class DPCodeWrapper[T](DeviceWrapper[T]):
         return device.status.get(self.dpcode)
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: T
+        self, device: CustomerDevice, value: Any
     ) -> Any:
         """Convert display value back to a raw device value.
 
@@ -180,11 +180,9 @@ class DPCodeBooleanWrapper[T = bool](
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: T
+        self, device: CustomerDevice, value: Any
     ) -> bool:
         """Convert a Home Assistant value back to a raw device value."""
-        if TYPE_CHECKING:
-            assert isinstance(value, bool)
         if value in (True, False):
             return value
         # Currently only called with boolean values
@@ -229,11 +227,9 @@ class DPCodeEnumWrapper[T = str](
         return raw_value  # type: ignore[no-any-return]
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: T
+        self, device: CustomerDevice, value: Any
     ) -> str:
         """Convert a Home Assistant value back to a raw device value."""
-        if TYPE_CHECKING:
-            assert isinstance(value, str)
         if value in self.type_information.range:
             return value
         # Guarded by select option validation
@@ -288,11 +284,9 @@ class DPCodeIntegerWrapper[T = float](
         return self.type_information.scale_value(raw_value)
 
     def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: T
+        self, device: CustomerDevice, value: Any
     ) -> int:
         """Convert a Home Assistant value back to a raw device value."""
-        if TYPE_CHECKING:
-            assert isinstance(value, float)
         new_value = self.type_information.scale_value_back(value)
         if self.type_information.min <= new_value <= self.type_information.max:
             return new_value

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -185,7 +185,11 @@ class DPCodeBooleanWrapper(
 
 
 class DPCodeEnumBaseWrapper(DPCodeTypeInformationWrapper[EnumTypeInformation]):
-    """Simple wrapper for EnumTypeInformation values."""
+    """Base wrapper for EnumTypeInformation values.
+
+    Provides typed `_read_device_status`, and `read_device_status` should be
+    implemented in subclass.
+    """
 
     _DPTYPE = EnumTypeInformation
     options: list[str]
@@ -303,7 +307,10 @@ class DPCodeIntegerWrapper(
 
 
 class DPCodeJsonBaseWrapper(DPCodeTypeInformationWrapper[JsonTypeInformation]):
-    """Simple wrapper for JsonTypeInformation values."""
+    """Base wrapper for JsonTypeInformation values.
+
+    Provides typed `_read_device_status`, and `read_device_status` should be
+    implemented in subclass."""
 
     _DPTYPE = JsonTypeInformation
 
@@ -331,7 +338,11 @@ class DPCodeJsonWrapper(DPCodeJsonBaseWrapper, DeviceWrapper[dict[str, Any]]):
 
 
 class DPCodeRawBaseWrapper(DPCodeTypeInformationWrapper[RawTypeInformation]):
-    """Simple wrapper for RawTypeInformation values."""
+    """Base wrapper for RawTypeInformation values.
+
+    Provides typed `_read_device_status`, and `read_device_status` should be
+    implemented in subclass.
+    """
 
     _DPTYPE = RawTypeInformation
 

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 from ..raw_data_model import ElectricityData
 from .base import DeviceWrapper
 from .common import (
-    DPCodeEnumWrapper,
+    DPCodeEnumBaseWrapper,
     DPCodeIntegerWrapper,
-    DPCodeJsonWrapper,
-    DPCodeRawWrapper,
+    DPCodeJsonBaseWrapper,
+    DPCodeRawBaseWrapper,
 )
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class WindDirectionEnumWrapper(DPCodeEnumWrapper, DeviceWrapper[str]):
+class WindDirectionEnumWrapper(DPCodeEnumBaseWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for converting enum to wind direction."""
 
     _WIND_DIRECTIONS = {
@@ -42,9 +42,9 @@ class WindDirectionEnumWrapper(DPCodeEnumWrapper, DeviceWrapper[str]):
         "north_north_west": 337.5,
     }
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := super()._read_device_status(device)) is None:
             return None
         return self._WIND_DIRECTIONS.get(status)
 
@@ -98,80 +98,84 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
         return self._accumulated_value
 
 
-class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityCurrentJsonWrapper(
+    DPCodeJsonBaseWrapper, DeviceWrapper[float]
+):
     """Custom DPCode Wrapper for extracting electricity current from JSON."""
 
     native_unit = "A"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := super()._read_device_status(device)) is None:
             return None
         return status.get("electricCurrent")
 
 
-class ElectricityPowerJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityPowerJsonWrapper(DPCodeJsonBaseWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from JSON."""
 
     native_unit = "kW"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := super()._read_device_status(device)) is None:
             return None
         return status.get("power")
 
 
-class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityVoltageJsonWrapper(
+    DPCodeJsonBaseWrapper, DeviceWrapper[float]
+):
     """Custom DPCode Wrapper for extracting electricity voltage from JSON."""
 
     native_unit = "V"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := super()._read_device_status(device)) is None:
             return None
         return status.get("voltage")
 
 
-class ElectricityCurrentRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityCurrentRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity current from base64."""
 
     native_unit = "mA"
     suggested_unit = "A"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super().read_device_status(device)) is None or (
+        if (raw_value := super()._read_device_status(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
         return value.current
 
 
-class ElectricityPowerRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityPowerRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from base64."""
 
     native_unit = "W"
     suggested_unit = "kW"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super().read_device_status(device)) is None or (
+        if (raw_value := super()._read_device_status(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
         return value.power
 
 
-class ElectricityVoltageRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityVoltageRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity voltage from base64."""
 
     native_unit = "V"
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super().read_device_status(device)) is None or (
+        if (raw_value := super()._read_device_status(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -44,7 +44,7 @@ class WindDirectionEnumWrapper(DPCodeEnumWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_dpcode_value(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return self._WIND_DIRECTIONS.get(status)
 
@@ -105,7 +105,7 @@ class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_dpcode_value(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return status.get("electricCurrent")
 
@@ -117,7 +117,7 @@ class ElectricityPowerJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_dpcode_value(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return status.get("power")
 
@@ -129,7 +129,7 @@ class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_dpcode_value(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return status.get("voltage")
 
@@ -142,7 +142,7 @@ class ElectricityCurrentRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_dpcode_value(device)) is None or (
+        if (raw_value := self._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
@@ -157,7 +157,7 @@ class ElectricityPowerRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_dpcode_value(device)) is None or (
+        if (raw_value := self._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
@@ -171,7 +171,7 @@ class ElectricityVoltageRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_dpcode_value(device)) is None or (
+        if (raw_value := self._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from ..raw_data_model import ElectricityData
-from .base import DeviceWrapper
 from .common import (
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class WindDirectionEnumWrapper(DPCodeEnumWrapper, DeviceWrapper[float]):
+class WindDirectionEnumWrapper(DPCodeEnumWrapper[float]):
     """Custom DPCode Wrapper for converting enum to wind direction."""
 
     _WIND_DIRECTIONS = {
@@ -98,7 +97,7 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
         return self._accumulated_value
 
 
-class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity current from JSON."""
 
     native_unit = "A"
@@ -110,7 +109,7 @@ class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
         return status.get("electricCurrent")
 
 
-class ElectricityPowerJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityPowerJsonWrapper(DPCodeJsonWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from JSON."""
 
     native_unit = "kW"
@@ -122,7 +121,7 @@ class ElectricityPowerJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
         return status.get("power")
 
 
-class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
+class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity voltage from JSON."""
 
     native_unit = "V"
@@ -134,7 +133,7 @@ class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
         return status.get("voltage")
 
 
-class ElectricityCurrentRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityCurrentRawWrapper(DPCodeRawWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity current from base64."""
 
     native_unit = "mA"
@@ -149,7 +148,7 @@ class ElectricityCurrentRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
         return value.current
 
 
-class ElectricityPowerRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityPowerRawWrapper(DPCodeRawWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from base64."""
 
     native_unit = "W"
@@ -164,7 +163,7 @@ class ElectricityPowerRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
         return value.power
 
 
-class ElectricityVoltageRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
+class ElectricityVoltageRawWrapper(DPCodeRawWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity voltage from base64."""
 
     native_unit = "V"

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 from ..raw_data_model import ElectricityData
 from .base import DeviceWrapper
 from .common import (
-    DPCodeEnumBaseWrapper,
+    DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
-    DPCodeJsonBaseWrapper,
-    DPCodeRawBaseWrapper,
+    DPCodeJsonWrapper,
+    DPCodeRawWrapper,
 )
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class WindDirectionEnumWrapper(DPCodeEnumBaseWrapper, DeviceWrapper[float]):
+class WindDirectionEnumWrapper(DPCodeEnumWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for converting enum to wind direction."""
 
     _WIND_DIRECTIONS = {
@@ -44,7 +44,7 @@ class WindDirectionEnumWrapper(DPCodeEnumBaseWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_device_status(device)) is None:
+        if (status := super()._read_dpcode_value(device)) is None:
             return None
         return self._WIND_DIRECTIONS.get(status)
 
@@ -77,7 +77,7 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
             or dp_timestamps is None
             or (current_timestamp := dp_timestamps.get(self.dpcode)) is None
             or current_timestamp == self._last_dp_timestamp
-            or (raw_value := super().read_device_status(device)) is None
+            or (raw_value := self._read_dpcode_value(device)) is None
         ):
             return True
 
@@ -98,47 +98,43 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
         return self._accumulated_value
 
 
-class ElectricityCurrentJsonWrapper(
-    DPCodeJsonBaseWrapper, DeviceWrapper[float]
-):
+class ElectricityCurrentJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity current from JSON."""
 
     native_unit = "A"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_device_status(device)) is None:
+        if (status := super()._read_dpcode_value(device)) is None:
             return None
         return status.get("electricCurrent")
 
 
-class ElectricityPowerJsonWrapper(DPCodeJsonBaseWrapper, DeviceWrapper[float]):
+class ElectricityPowerJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from JSON."""
 
     native_unit = "kW"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_device_status(device)) is None:
+        if (status := super()._read_dpcode_value(device)) is None:
             return None
         return status.get("power")
 
 
-class ElectricityVoltageJsonWrapper(
-    DPCodeJsonBaseWrapper, DeviceWrapper[float]
-):
+class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity voltage from JSON."""
 
     native_unit = "V"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (status := super()._read_device_status(device)) is None:
+        if (status := super()._read_dpcode_value(device)) is None:
             return None
         return status.get("voltage")
 
 
-class ElectricityCurrentRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
+class ElectricityCurrentRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity current from base64."""
 
     native_unit = "mA"
@@ -146,14 +142,14 @@ class ElectricityCurrentRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_device_status(device)) is None or (
+        if (raw_value := super()._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
         return value.current
 
 
-class ElectricityPowerRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
+class ElectricityPowerRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity power from base64."""
 
     native_unit = "W"
@@ -161,21 +157,21 @@ class ElectricityPowerRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_device_status(device)) is None or (
+        if (raw_value := super()._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None
         return value.power
 
 
-class ElectricityVoltageRawWrapper(DPCodeRawBaseWrapper, DeviceWrapper[float]):
+class ElectricityVoltageRawWrapper(DPCodeRawWrapper, DeviceWrapper[float]):
     """Custom DPCode Wrapper for extracting electricity voltage from base64."""
 
     native_unit = "V"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
-        if (raw_value := super()._read_device_status(device)) is None or (
+        if (raw_value := super()._read_dpcode_value(device)) is None or (
             value := ElectricityData.from_bytes(raw_value)
         ) is None:
             return None

--- a/tests/device_wrapper/test_sensor.py
+++ b/tests/device_wrapper/test_sensor.py
@@ -101,7 +101,7 @@ def _snapshot_sensor(
     ],
 )
 def test_sensor_wrapper(
-    wrapper_type: type[DPCodeTypeInformationWrapper[Any]],
+    wrapper_type: type[DPCodeTypeInformationWrapper[Any, Any]],
     dpcode: str,
     status_range: str,
     status: Any,
@@ -171,7 +171,7 @@ def test_sensor_wrapper(
     ],
 )
 def test_sensor_invalid_value(
-    wrapper_type: type[DPCodeTypeInformationWrapper[Any]],
+    wrapper_type: type[DPCodeTypeInformationWrapper[Any, Any]],
     dpcode: str,
     status_range: str,
     status: str,


### PR DESCRIPTION
`DeviceWrapper` is already a generic.

This PR improves type hints by ensuring all intermediate subclasses are also generics.

Base DPCode wrappers do not have a default type:
- `DPCodeWrapper[T](DeviceWrapper[T])`
- `DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation, T]`

First level type information wrappers have a default type:
-  `DPCodeBitmapWrapper[T = int](DPCodeTypeInformationWrapper[BitmapTypeInformation, T])`
-  `DPCodeBooleanWrapper[T = bool](DPCodeTypeInformationWrapper[BooleanTypeInformation, T])`
-  `DPCodeEnumWrapper[T = str](DPCodeTypeInformationWrapper[EnumTypeInformation, T])`
-  `DPCodeIntegerWrapper[T = float](DPCodeTypeInformationWrapper[IntegerTypeInformation, T])`
-  `DPCodeJsonWrapper[T = dict[str, Any]](DPCodeTypeInformationWrapper[JsonTypeInformation, T])`
-  `DPCodeRawWrapper[T = bytes](DPCodeTypeInformationWrapper[RawTypeInformation, T])`
-  `DPCodeStringWrapper[T = str](DPCodeTypeInformationWrapper[StringTypeInformation, T])`

Fix some type issues with end classes by adding a protected method `_read_dpcode_value` to make the intermediate device value available to the end classes (read, validated, and converted based on Tuya type information).
This allows the end classes to override the return type of `read_device_status` without generating `mypy` errors and allows us to drop `type: ignore[override]`, for example:
- `str to float` if the end wrapper maps wind direction string enum to numeric angle
- `int to bool` if the end wrapper reads a single bit from a bitmap int value
- `bytes to float` if the end wrapper extracts a float value from a complex binary object
- `dict[str, Any] to float` if the end wrapper extracts a float value from a JSON object

It also means the end classes no longer need to inherit `DeviceWrapper` base class.
