### PR TITLE
Fix QuirksRegistry singleton wiping state on re-instantiation

### DIFF
--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -39,7 +39,8 @@ class QuirksRegistry:
 
     def __init__(self) -> None:
         """Initialize the registry."""
-        self._quirks = {}
+        if not hasattr(self, "_quirks"):
+            self._quirks = {}
 
     def register(
         self,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,26 @@
+"""Tests for the quirks registry."""
+
+from unittest.mock import Mock
+
+from tuya_sharing import CustomerDevice
+
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_singleton_preserves_state() -> None:
+    """Test that re-instantiating QuirksRegistry does not wipe registered quirks."""
+    reg = QuirksRegistry()
+
+    # Register a quirk
+    quirk = Mock()
+    device = Mock(spec=CustomerDevice)
+    device.product_id = "test_product_singleton"
+    reg.register("test_product_singleton", quirk)
+
+    # Second instantiation should return same instance with data intact
+    reg2 = QuirksRegistry()
+    assert reg2 is reg
+    assert reg2.get_quirk_for_device(device) is quirk
+
+    # Cleanup
+    reg._quirks.pop("test_product_singleton", None)


### PR DESCRIPTION
The `QuirksRegistry` uses a singleton pattern via `__new__`, but `__init__` unconditionally resets `_quirks = {}` every time `QuirksRegistry()` is called. This means a second instantiation silently wipes all registered quirks.

Guard the initialization with `hasattr` so `_quirks` is only set once.
