### PR TITLE
Fix TBD URL in custom quirks log message

### DIFF
--- a/src/tuya_device_handlers/devices/__init__.py
+++ b/src/tuya_device_handlers/devices/__init__.py
@@ -62,5 +62,5 @@ def register_tuya_quirks(custom_quirks_path: str | None = None) -> None:
 
     if loaded:
         _LOGGER.warning(
-            "Loaded custom quirks. Please contribute them to https://github.com/TBD"
+            "Loaded custom quirks. Please contribute them to https://github.com/home-assistant-libs/tuya-device-handlers"
         )


### PR DESCRIPTION
The log message shown when custom quirks are loaded points users to https://github.com/TBD. Replace with the actual repository URL.