### PR TITLE
Remove unused deprecated aliases

### DIFF
--- a/src/tuya_device_handlers/definition/alarm_control_panel.py
+++ b/src/tuya_device_handlers/definition/alarm_control_panel.py
@@ -26,10 +26,6 @@ class AlarmControlPanelDefinition:
     state_wrapper: DeviceWrapper[TuyaAlarmControlPanelState]
 
 
-# Deprecated alias for backward compatibility
-TuyaAlarmControlPanelDefinition = AlarmControlPanelDefinition
-
-
 @dataclass(kw_only=True)
 class AlarmControlPanelQuirk(BaseEntityQuirk):
     """Quirk for an alarm control panel entity."""

--- a/src/tuya_device_handlers/definition/binary_sensor.py
+++ b/src/tuya_device_handlers/definition/binary_sensor.py
@@ -19,10 +19,6 @@ class BinarySensorDefinition:
     binary_sensor_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaBinarySensorDefinition = BinarySensorDefinition
-
-
 @dataclass(kw_only=True)
 class BinarySensorQuirk(BaseEntityQuirk):
     """Quirk for a binary sensor entity."""

--- a/src/tuya_device_handlers/definition/button.py
+++ b/src/tuya_device_handlers/definition/button.py
@@ -15,10 +15,6 @@ class ButtonDefinition:
     button_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaButtonDefinition = ButtonDefinition
-
-
 @dataclass(kw_only=True)
 class ButtonQuirk(BaseEntityQuirk):
     """Quirk for a button entity."""

--- a/src/tuya_device_handlers/definition/camera.py
+++ b/src/tuya_device_handlers/definition/camera.py
@@ -16,10 +16,6 @@ class CameraDefinition:
     recording_status: DeviceWrapper[bool] | None
 
 
-# Deprecated alias for backward compatibility
-TuyaCameraDefinition = CameraDefinition
-
-
 @dataclass(kw_only=True)
 class CameraQuirk(BaseEntityQuirk):
     """Quirk for a camera entity."""

--- a/src/tuya_device_handlers/definition/climate.py
+++ b/src/tuya_device_handlers/definition/climate.py
@@ -40,10 +40,6 @@ class ClimateDefinition:
     temperature_unit: TuyaUnitOfTemperature
 
 
-# Deprecated alias for backward compatibility
-TuyaClimateDefinition = ClimateDefinition
-
-
 @dataclass(kw_only=True)
 class ClimateQuirk(BaseEntityQuirk):
     """Quirk for a climate entity."""

--- a/src/tuya_device_handlers/definition/cover.py
+++ b/src/tuya_device_handlers/definition/cover.py
@@ -26,7 +26,6 @@ class CoverDefinition:
     tilt_position_wrapper: DeviceWrapper[int] | None
 
 
-
 @dataclass(kw_only=True)
 class CoverQuirk(BaseEntityQuirk):
     """Quirk for a cover entity."""

--- a/src/tuya_device_handlers/definition/cover.py
+++ b/src/tuya_device_handlers/definition/cover.py
@@ -26,9 +26,6 @@ class CoverDefinition:
     tilt_position_wrapper: DeviceWrapper[int] | None
 
 
-# Deprecated alias for backward compatibility
-TuyaCoverDefinition = CoverDefinition
-
 
 @dataclass(kw_only=True)
 class CoverQuirk(BaseEntityQuirk):

--- a/src/tuya_device_handlers/definition/event.py
+++ b/src/tuya_device_handlers/definition/event.py
@@ -17,10 +17,6 @@ class EventDefinition:
     event_wrapper: DeviceWrapper[tuple[str, dict[str, Any] | None]]
 
 
-# Deprecated alias for backward compatibility
-TuyaEventDefinition = EventDefinition
-
-
 @dataclass(kw_only=True)
 class EventQuirk(BaseEntityQuirk):
     """Quirk for an event entity."""

--- a/src/tuya_device_handlers/definition/fan.py
+++ b/src/tuya_device_handlers/definition/fan.py
@@ -25,10 +25,6 @@ class FanDefinition:
     switch_wrapper: DeviceWrapper[bool] | None
 
 
-# Deprecated alias for backward compatibility
-TuyaFanDefinition = FanDefinition
-
-
 @dataclass(kw_only=True)
 class FanQuirk(BaseEntityQuirk):
     """Quirk for a fan entity."""

--- a/src/tuya_device_handlers/definition/humidifier.py
+++ b/src/tuya_device_handlers/definition/humidifier.py
@@ -19,10 +19,6 @@ class HumidifierDefinition:
     target_humidity_wrapper: DeviceWrapper[int] | None = None
 
 
-# Deprecated alias for backward compatibility
-TuyaHumidifierDefinition = HumidifierDefinition
-
-
 @dataclass(kw_only=True)
 class HumidifierQuirk(BaseEntityQuirk):
     """Quirk for a humidifier entity."""

--- a/src/tuya_device_handlers/definition/light.py
+++ b/src/tuya_device_handlers/definition/light.py
@@ -35,7 +35,6 @@ class LightDefinition:
     switch_wrapper: DeviceWrapper[bool]
 
 
-
 @dataclass(kw_only=True)
 class LightQuirk(BaseEntityQuirk):
     """Quirk for a light entity."""

--- a/src/tuya_device_handlers/definition/light.py
+++ b/src/tuya_device_handlers/definition/light.py
@@ -35,9 +35,6 @@ class LightDefinition:
     switch_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaLightDefinition = LightDefinition
-
 
 @dataclass(kw_only=True)
 class LightQuirk(BaseEntityQuirk):

--- a/src/tuya_device_handlers/definition/number.py
+++ b/src/tuya_device_handlers/definition/number.py
@@ -15,10 +15,6 @@ class NumberDefinition:
     number_wrapper: DeviceWrapper[float]
 
 
-# Deprecated alias for backward compatibility
-TuyaNumberDefinition = NumberDefinition
-
-
 @dataclass(kw_only=True)
 class NumberQuirk(BaseEntityQuirk):
     """Quirk for a number entity."""

--- a/src/tuya_device_handlers/definition/select.py
+++ b/src/tuya_device_handlers/definition/select.py
@@ -15,10 +15,6 @@ class SelectDefinition:
     select_wrapper: DeviceWrapper[str]
 
 
-# Deprecated alias for backward compatibility
-TuyaSelectDefinition = SelectDefinition
-
-
 @dataclass(kw_only=True)
 class SelectQuirk(BaseEntityQuirk):
     """Quirk for a select entity."""

--- a/src/tuya_device_handlers/definition/sensor.py
+++ b/src/tuya_device_handlers/definition/sensor.py
@@ -21,9 +21,6 @@ class SensorDefinition:
     sensor_wrapper: DeviceWrapper[str | int | float]
 
 
-# Deprecated alias for backward compatibility
-TuyaSensorDefinition = SensorDefinition
-
 
 @dataclass(kw_only=True)
 class SensorQuirk(BaseEntityQuirk):

--- a/src/tuya_device_handlers/definition/sensor.py
+++ b/src/tuya_device_handlers/definition/sensor.py
@@ -21,7 +21,6 @@ class SensorDefinition:
     sensor_wrapper: DeviceWrapper[str | int | float]
 
 
-
 @dataclass(kw_only=True)
 class SensorQuirk(BaseEntityQuirk):
     """Quirk for a sensor entity."""

--- a/src/tuya_device_handlers/definition/siren.py
+++ b/src/tuya_device_handlers/definition/siren.py
@@ -15,10 +15,6 @@ class SirenDefinition:
     siren_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaSirenDefinition = SirenDefinition
-
-
 @dataclass(kw_only=True)
 class SirenQuirk(BaseEntityQuirk):
     """Quirk for a siren entity."""

--- a/src/tuya_device_handlers/definition/switch.py
+++ b/src/tuya_device_handlers/definition/switch.py
@@ -15,10 +15,6 @@ class SwitchDefinition:
     switch_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaSwitchDefinition = SwitchDefinition
-
-
 @dataclass(kw_only=True)
 class SwitchQuirk(BaseEntityQuirk):
     """Definition for a switch entity."""

--- a/src/tuya_device_handlers/definition/vacuum.py
+++ b/src/tuya_device_handlers/definition/vacuum.py
@@ -19,10 +19,6 @@ class VacuumDefinition:
     fan_speed_wrapper: DeviceWrapper[str] | None
 
 
-# Deprecated alias for backward compatibility
-TuyaVacuumDefinition = VacuumDefinition
-
-
 @dataclass(kw_only=True)
 class VacuumQuirk(BaseEntityQuirk):
     """Quirk for a vacuum entity."""

--- a/src/tuya_device_handlers/definition/valve.py
+++ b/src/tuya_device_handlers/definition/valve.py
@@ -15,10 +15,6 @@ class ValveDefinition:
     control_wrapper: DeviceWrapper[bool]
 
 
-# Deprecated alias for backward compatibility
-TuyaValveDefinition = ValveDefinition
-
-
 @dataclass(kw_only=True)
 class ValveQuirk(BaseEntityQuirk):
     """Quirk for a valve entity."""


### PR DESCRIPTION
Remove the `TuyaSensorDefinition`, `TuyaLightDefinition`, and `TuyaCoverDefinition` aliases. They were marked as "deprecated alias for backward compatibility" but nothing imports them.