### PR TITLE
Migrate pyproject.toml to PEP 621 + Poetry v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -612,6 +612,7 @@ description = "A utility for ensuring Google-style docstrings stay up to date wi
 optional = false
 python-versions = ">=3.6,<4.0"
 groups = ["dev"]
+markers = "python_version < \"4.0\""
 files = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
@@ -2658,5 +2659,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12,<4.0"
-content-hash = "c0ef7b74b2fd3290b64195b0c5c8bbe038c64b19b9fa9cc1c5ac9bf3f76055fd"
+python-versions = ">=3.12"
+content-hash = "f73033d1318fec4d05af5c1f26f733fe96b59822e13a48bd692428a7c41ddf34"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,55 +1,54 @@
-[tool.poetry]
+[project]
 name = "tuya-device-handlers"
 version = "0.0.18"
 description = "Tuya quirks library"
-authors = ["epenet"]
+authors = [{ name = "epenet" }]
 license = "MIT"
+requires-python = ">=3.12"
 readme = "README.md"
+keywords = ["tuya"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Home Automation",
+]
+dynamic = ["dependencies"]
+packages = [{ include = "tuya_device_handlers", from = "src" }]
+dependencies = ['tuya-device-sharing-sdk (>=0.2.8)']
+
+[tool.poetry]
+requires-poetry = '>=2.0'
+
+[project.urls]
 homepage = "https://github.com/home-assistant-libs/tuya-device-handlers"
 repository = "https://github.com/home-assistant-libs/tuya-device-handlers"
 documentation = "https://tuya-device-handlers.readthedocs.io"
-keywords=["tuya"]
-classifiers = [
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Intended Audience :: Developers",
-    "Intended Audience :: System Administrators",
-    "Topic :: Home Automation",
-]
-
-[tool.poetry.urls]
 Changelog = "https://github.com/home-assistant-libs/tuya-device-handlers/releases"
 
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.8"
-
-[tool.poetry.dependencies]
-python = ">=3.12,<4.0"
-tuya-device-sharing-sdk = ">=0.2.8"
-
 [tool.poetry.group.dev.dependencies]
-Pygments = "==2.20.0"
-ruff = "==0.15.9"
-coverage = {extras = ["toml"], version = "==7.13.5"}
-darglint = "==1.8.1"
+Pygments = "2.20.0"
+ruff = "0.15.9"
+coverage = { version = "7.13.5", extras = ["toml"] }
+darglint = { version = "1.8.1", python = "<4.0" }
 mypy = "1.20.0"
-pre-commit = "==4.5.1"
-pre-commit-hooks = "==6.0.0"
-pytest = "==9.0.3"
-pytest-asyncio = "==1.3.0"
-pytest-cov = "==7.1.0"
-safety = "==3.7.0"
-syrupy = "==5.1.0"
-typeguard = "==4.5.1"
+pre-commit = "4.5.1"
+pre-commit-hooks = "6.0.0"
+pytest = "9.0.3"
+pytest-asyncio = "1.3.0"
+pytest-cov = "7.1.0"
+safety = "3.7.0"
+syrupy = "5.1.0"
+typeguard = "4.5.1"
 
 # docs (Python >= 3.14)
-furo = {version = "==2025.12.19", python = ">=3.14"}
-myst-parser = {version = "==5.0.0", python = ">=3.14"}
-sphinx = {version = "==9.1.0", python = ">=3.14"}
-sphinx-autobuild = {version = "==2025.8.25", python = ">=3.14"}
-sphinx-click = {version = "==6.2.0", python = ">=3.14"}
+furo = { version = "2025.12.19", python = ">=3.14" }
+myst-parser = { version = "5.0.0", python = ">=3.14" }
+sphinx = { version = "9.1.0", python = ">=3.14" }
+sphinx-autobuild = { version = "2025.8.25", python = ">=3.14" }
+sphinx-click = { version = "6.2.0", python = ">=3.14" }
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
@@ -129,5 +128,5 @@ max-complexity = 10
 convention = "google"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Topic :: Home Automation",
 ]
 dynamic = ["dependencies"]
-packages = [{ include = "tuya_device_handlers", from = "src" }]
 dependencies = ['tuya-device-sharing-sdk (>=0.2.8)']
 
 [tool.poetry]


### PR DESCRIPTION
Migrate project metadata from Poetry's proprietary `[tool.poetry]` format to the standardized PEP 621 `[project]` table, and update the build system to Poetry v2.

## Changes

- Convert `[tool.poetry]` metadata to `[project]` table (PEP 621)
- Convert `[tool.poetry.urls]` to `[project.urls]`
- Convert `[tool.poetry.dependencies]` to `dependencies` with `dynamic = ["dependencies"]`
- Add `requires-python = ">=3.12"` (replaces `python =` in deps section)
- Add `requires-poetry = '>=2.0'`
- Remove `[tool.poetry.requires-plugins]`
- Update build-system to `poetry-core>=2.0`
- Normalize dev dependency pin format (`==` → plain version)
- Add `python = "<4.0"` constraint to `darglint` (needed for Poetry v2 resolver)
- Remove redundant `License :: OSI Approved :: MIT License` classifier (covered by `license` field)
- Regenerate `poetry.lock`

No tool configuration, rule, or dependency changes.