### PR TITLE
Add covdefaults for coverage configuration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -158,6 +158,7 @@ def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".[cli]")
     session.install(
+        "covdefaults",
         "coverage[toml]",
         "pytest",
         "pygments",
@@ -179,7 +180,7 @@ def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report"]
 
-    session.install("coverage[toml]")
+    session.install("covdefaults", "coverage[toml]")
 
     if not session.posargs and any(Path().glob(".coverage.*")):
         session.run("coverage", "combine")

--- a/poetry.lock
+++ b/poetry.lock
@@ -422,6 +422,21 @@ files = [
 ]
 
 [[package]]
+name = "covdefaults"
+version = "2.3.0"
+description = "A coverage plugin to provide sensible default settings"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "covdefaults-2.3.0-py2.py3-none-any.whl", hash = "sha256:2832961f6ffcfe4b57c338bc3418a3526f495c26fb9c54565409c5532f7c41be"},
+    {file = "covdefaults-2.3.0.tar.gz", hash = "sha256:4e99f679f12d792bc62e5510fa3eb59546ed47bd569e36e4fddc4081c9c3ebf7"},
+]
+
+[package.dependencies]
+coverage = ">=6.0.2"
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 description = "Code coverage measurement for Python"
@@ -2489,4 +2504,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "2f1bfb37e2cd3366f112b0058812e62d99d2f2910003d30fe35e39afd5d2b58e"
+content-hash = "e7b2509505ec075103c2e2d2fb7601185149bbfdd7eb9fbb60030392608686e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ Changelog = "https://github.com/home-assistant-libs/tuya-device-handlers/release
 [tool.poetry.group.dev.dependencies]
 Pygments = "2.20.0"
 ruff = "0.15.9"
+covdefaults = "2.3.0"
 coverage = { version = "7.13.5", extras = ["toml"] }
 darglint = { version = "1.8.1", python = "<4.0" }
 ty = "0.0.32"
@@ -49,22 +50,13 @@ sphinx = { version = "9.1.0", python = ">=3.14" }
 sphinx-autobuild = { version = "2025.8.25", python = ">=3.14" }
 sphinx-click = { version = "6.2.0", python = ">=3.14" }
 
-[tool.coverage.paths]
-source = ["src", "*/site-packages"]
-tests = ["tests", "*/tests"]
-
 [tool.coverage.run]
-branch = true
+plugins = ["covdefaults"]
 source = ["tuya_device_handlers"]
 
 [tool.coverage.report]
 show_missing = true
-exclude_lines = [
-  # Don't complain if tests don't hit defensive assertion code:
-  "raise NotImplementedError",
-  # TYPE_CHECKING blocks are never executed during pytest run
-  "if TYPE_CHECKING:",
-]
+fail_under = 90
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
Add the `covdefaults` plugin for `coverage.py`, which provides sensible default settings for Python coverage measurement.

- Add `covdefaults` dev dependency
- Simplify `[tool.coverage.*]` config: remove `paths`, `branch`, and `exclude_lines` sections (covdefaults handles these automatically, including excluding `TYPE_CHECKING` blocks, `raise NotImplementedError`, abstract methods, etc.)
- Add `fail_under = 90` coverage threshold (currently at 91% IRL)
