### PR TITLE
Remove darglint

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,2 +1,0 @@
-[darglint]
-strictness = long

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ repos:
         entry: check-yaml
         language: system
         types: [yaml]
-      - id: darglint
-        name: darglint
-        entry: darglint
-        language: system
-        types: [python]
-        stages: [manual]
       - id: end-of-file-fixer
         name: Fix End of Files
         entry: end-of-file-fixer

--- a/noxfile.py
+++ b/noxfile.py
@@ -120,7 +120,6 @@ def precommit(session: Session) -> None:
         "--show-diff-on-failure",
     ]
     session.install(
-        "darglint",
         "pre-commit",
         "pre-commit-hooks",
         "ruff",

--- a/poetry.lock
+++ b/poetry.lock
@@ -606,19 +606,6 @@ cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and pla
 ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
-name = "darglint"
-version = "1.8.1"
-description = "A utility for ensuring Google-style docstrings stay up to date with the source code."
-optional = false
-python-versions = ">=3.6,<4.0"
-groups = ["dev"]
-markers = "python_version < \"4.0\""
-files = [
-    {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
-    {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -2489,4 +2476,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "2f1bfb37e2cd3366f112b0058812e62d99d2f2910003d30fe35e39afd5d2b58e"
+content-hash = "7fbc395229dcfc378662558c0af4f3ff47624a411ee949a285af30eba93931ef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ Changelog = "https://github.com/home-assistant-libs/tuya-device-handlers/release
 Pygments = "2.20.0"
 ruff = "0.15.9"
 coverage = { version = "7.13.5", extras = ["toml"] }
-darglint = { version = "1.8.1", python = "<4.0" }
 ty = "0.0.32"
 pre-commit = "4.5.1"
 pre-commit-hooks = "6.0.0"


### PR DESCRIPTION
Remove darglint, a docstring linter that has been [archived since 2022](https://github.com/terrencepreilly/darglint).

Ruff already covers docstring linting via the `D` and `DOC` rule sets.

- Remove `darglint` dev dependency
- Delete `.darglint` config file
- Remove darglint hook from `.pre-commit-config.yaml`
- Remove darglint from nox pre-commit session
- Regenerate `poetry.lock`