### PR TITLE
Remove typeguard and Pygments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
           - { python-version: "3.14", os: ubuntu-latest, session: "ty" }
           - { python-version: "3.14", os: ubuntu-latest, session: "tests" }
           - { python-version: "3.13", os: ubuntu-latest, session: "tests" }
-          - { python-version: "3.14", os: ubuntu-latest, session: "typeguard" }
           - { python-version: "3.14", os: ubuntu-latest, session: "docs-build" }
 
     env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,6 @@ nox.options.sessions = (
     "safety",
     "ty",
     "tests",
-    "typeguard",
     "docs-build",
 )
 
@@ -184,21 +183,6 @@ def coverage(session: Session) -> None:
         session.run("coverage", "combine")
 
     session.run("coverage", *args)
-
-
-@session(python=python_versions[0])
-def typeguard(session: Session) -> None:
-    """Runtime type checking using Typeguard."""
-    session.install(".[cli]")
-    session.install(
-        "pytest",
-        "typeguard",
-        "pygments",
-        "pytest-asyncio",
-        "cryptography",
-        "syrupy",
-    )
-    session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
 @session(name="docs-build", python=python_versions[0])

--- a/poetry.lock
+++ b/poetry.lock
@@ -2163,21 +2163,6 @@ files = [
 ]
 
 [[package]]
-name = "typeguard"
-version = "4.5.1"
-description = "Run-time type checker for Python"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40"},
-    {file = "typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274"},
-]
-
-[package.dependencies]
-typing_extensions = ">=4.14.0"
-
-[[package]]
 name = "typer"
 version = "0.25.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -2476,4 +2461,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "7fbc395229dcfc378662558c0af4f3ff47624a411ee949a285af30eba93931ef"
+content-hash = "7118d6411bcb9cfc114e8f80d7cf91f573cc75b9dba869c7040e9ab3e0202abc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ documentation = "https://tuya-device-handlers.readthedocs.io"
 Changelog = "https://github.com/home-assistant-libs/tuya-device-handlers/releases"
 
 [tool.poetry.group.dev.dependencies]
-Pygments = "2.20.0"
 ruff = "0.15.9"
 coverage = { version = "7.13.5", extras = ["toml"] }
 ty = "0.0.32"
@@ -39,7 +38,6 @@ pytest-asyncio = "1.3.0"
 pytest-cov = "7.1.0"
 safety = "3.7.0"
 syrupy = "5.1.0"
-typeguard = "4.5.1"
 
 # docs (Python >= 3.14)
 furo = { version = "2025.12.19", python = ">=3.14" }

--- a/tests/device_wrapper/test_alarm_control_panel.py
+++ b/tests/device_wrapper/test_alarm_control_panel.py
@@ -17,13 +17,6 @@ from tuya_device_handlers.helpers.homeassistant import (
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 def _inject_default_alarm_codes(mock_device: CustomerDevice) -> None:
     inject_dpcode(mock_device, "alarm_msg", "**REDACTED**", dptype="Raw")

--- a/tests/device_wrapper/test_climate.py
+++ b/tests/device_wrapper/test_climate.py
@@ -17,13 +17,6 @@ from tuya_device_handlers.helpers.homeassistant import (
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     (

--- a/tests/device_wrapper/test_common.py
+++ b/tests/device_wrapper/test_common.py
@@ -1,7 +1,6 @@
 """Test DeviceWrapper classes"""
 
 import base64
-from contextlib import nullcontext as suppress_type_checks
 from typing import Any
 
 import pytest
@@ -121,7 +120,7 @@ def test_get_update_commands_value_error(
     wrapper = wrapper_type.find_dpcode(mock_device, dpcode)
 
     assert wrapper
-    with suppress_type_checks(), pytest.raises(SetValueOutOfRangeError):
+    with pytest.raises(SetValueOutOfRangeError):
         wrapper.get_update_commands(mock_device, value)
 
 

--- a/tests/device_wrapper/test_common.py
+++ b/tests/device_wrapper/test_common.py
@@ -1,6 +1,7 @@
 """Test DeviceWrapper classes"""
 
 import base64
+from contextlib import nullcontext as suppress_type_checks
 from typing import Any
 
 import pytest
@@ -17,13 +18,6 @@ from tuya_device_handlers.device_wrapper.common import (
     DPCodeStringWrapper,
     DPCodeTypeInformationWrapper,
 )
-
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
 
 
 def test_dpcode_not_found(

--- a/tests/device_wrapper/test_cover.py
+++ b/tests/device_wrapper/test_cover.py
@@ -23,13 +23,6 @@ from tuya_device_handlers.helpers.homeassistant import TuyaCoverAction
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     ("wrapper_type", "dpcode", "status_updates", "expected_device_status"),

--- a/tests/device_wrapper/test_event.py
+++ b/tests/device_wrapper/test_event.py
@@ -14,13 +14,6 @@ from tuya_device_handlers.device_wrapper.event import (
     SimpleEventEnumWrapper,
 )
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     ("wrapper_type", "dpcode", "status", "expected_device_status"),

--- a/tests/device_wrapper/test_extended.py
+++ b/tests/device_wrapper/test_extended.py
@@ -15,13 +15,6 @@ from tuya_device_handlers.device_wrapper.extended import (
     DPCodeRoundedIntegerWrapper,
 )
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     ("wrapper_type", "dpcode", "status", "expected_device_status"),

--- a/tests/device_wrapper/test_fan.py
+++ b/tests/device_wrapper/test_fan.py
@@ -17,13 +17,6 @@ from tuya_device_handlers.helpers.homeassistant import TuyaFanDirection
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     ("wrapper_type", "dpcode", "status", "expected_device_status"),

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -18,13 +18,6 @@ from tuya_device_handlers.utils import RemapHelper
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 def _inject_default_light(mock_device: CustomerDevice) -> None:
     inject_dpcode(

--- a/tests/device_wrapper/test_vacuum.py
+++ b/tests/device_wrapper/test_vacuum.py
@@ -16,13 +16,6 @@ from tuya_device_handlers.helpers.homeassistant import (
 
 from . import inject_dpcode
 
-try:
-    from typeguard import suppress_type_checks  # ty: ignore[unresolved-import]
-except ImportError:
-    from contextlib import nullcontext
-
-    suppress_type_checks: Any = nullcontext
-
 
 @pytest.mark.parametrize(
     ("sample", "status_updates", "expected_device_status"),


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

Remove `typeguard` (runtime type checking) and `Pygments` (syntax highlighting). Both are unused. `typeguard` was part of the Hypermodern Python Cookiecutter template, and `Pygments` was only needed for the `typeguard` `nox` session.

- Remove `typeguard` and `Pygments` dev dependencies
- Remove typeguard nox session
- Remove typeguard from CI test matrix
- Remove `suppress_type_checks` from all test files (was a no-op `nullcontext` wrapper only needed when typeguard was installed)
- Regenerate `poetry.lock`
 
## Test plan

Removed all code and ensure pytest still passed.

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

n/a
