### PR TITLE
Add manufacturer and model to device quirk

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -70,7 +70,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     def __init__(self) -> None:
         """Initialize the quirk."""
-        self._applies_to: list[str] = []
+        self._applies_to: str | None = None
 
         self._datapoint_definitions = {}
         self._get_wrapper_functions = {}
@@ -139,15 +139,20 @@ class DeviceQuirk(DeviceQuirkProtocol):
         model: str | None = None,
     ) -> Self:
         """Set the device type the quirk applies to."""
-        self._applies_to.append(product_id)
+        if self._applies_to is not None:
+            raise ValueError("DeviceQuirk already has an applies_to condition")
+        self._applies_to = product_id
         self.manufacturer = manufacturer
         self.model = model
         return self
 
     def register(self, registry: QuirksRegistry) -> None:
         """Register the quirk in the registry."""
-        for product_id in self._applies_to:
-            registry.register(product_id, self)
+        if self._applies_to is None:
+            raise ValueError(
+                "DeviceQuirk does not have an applies_to condition"
+            )
+        registry.register(self._applies_to, self)
 
     def add_dpid_bitmap(
         self, *, dpid: int, dpcode: str, dpmode: DPMode, label_range: list[str]

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -121,9 +121,17 @@ class DeviceQuirk(DeviceQuirkProtocol):
             else:
                 device.local_strategy.pop(definition.dpid, None)
 
-    def applies_to(self, *, product_id: str) -> Self:
+    def applies_to(
+        self,
+        *,
+        product_id: str,
+        manufacturer: str | None = None,
+        model: str | None = None,
+    ) -> Self:
         """Set the device type the quirk applies to."""
         self._applies_to.append(product_id)
+        self.manufacturer = manufacturer
+        self.model = model
         return self
 
     def register(self, registry: QuirksRegistry) -> None:

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -16,6 +16,9 @@ class DeviceQuirkProtocol(Protocol):
     original_local_strategy: dict[int, dict[str, Any]]
     original_status_range: dict[str, DeviceStatusRange]
 
+    manufacturer: str | None = None
+    model: str | None = None
+
     @property
     def quirk_file(self) -> pathlib.Path: ...
     @property

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -21,8 +21,8 @@ class DeviceQuirkProtocol(Protocol):
     original_local_strategy: dict[int, dict[str, Any]]
     original_status_range: dict[str, DeviceStatusRange]
 
-    manufacturer: str | None = None
-    model: str | None = None
+    manufacturer: str | None
+    model: str | None
 
     @property
     def quirk_file(self) -> pathlib.Path: ...

--- a/tests/builder/__init__.py
+++ b/tests/builder/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for builder helpers."""

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -1,0 +1,14 @@
+"""Tests for DeviceQuirk."""
+
+from tuya_device_handlers.builder.device_quirk import DeviceQuirk
+
+
+def test_applies_to_records_manufacturer_and_model() -> None:
+    """applies_to stores manufacturer and model as readable attributes."""
+    quirk = DeviceQuirk().applies_to(
+        product_id="abc",
+        manufacturer="Acme",
+        model="Widget-1",
+    )
+    assert quirk.manufacturer == "Acme"
+    assert quirk.model == "Widget-1"

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -1,6 +1,9 @@
 """Tests for DeviceQuirk."""
 
+import pytest
+
 from tuya_device_handlers.builder.device_quirk import DeviceQuirk
+from tuya_device_handlers.registry import QuirksRegistry
 
 
 def test_applies_to_records_manufacturer_and_model() -> None:
@@ -12,3 +15,19 @@ def test_applies_to_records_manufacturer_and_model() -> None:
     )
     assert quirk.manufacturer == "Acme"
     assert quirk.model == "Widget-1"
+
+
+def test_applies_to_called_twice_raises() -> None:
+    """Calling applies_to a second time raises ValueError."""
+    quirk = DeviceQuirk().applies_to(product_id="abc")
+    with pytest.raises(ValueError, match="already has an applies_to condition"):
+        quirk.applies_to(product_id="def")
+
+
+def test_register_without_applies_to_raises() -> None:
+    """register raises ValueError when applies_to was never called."""
+    quirk = DeviceQuirk()
+    with pytest.raises(
+        ValueError, match="does not have an applies_to condition"
+    ):
+        quirk.register(QuirksRegistry())


### PR DESCRIPTION
These are currently hard-coded in Home Assistant:
https://github.com/home-assistant/core/blob/77bd6a720d8227e652079e6e5f8391817b9d6bb1/homeassistant/components/tuya/coordinator.py#L149-L155