### PR TITLE
Add ability to declare feeder schedules wrapper in quirk

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -1,5 +1,6 @@
 """Base quirk definition."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 import inspect
 import json
@@ -9,6 +10,10 @@ from typing import TYPE_CHECKING, Any, Self
 from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
 from tuya_device_handlers.const import DPMode, DPType
+from tuya_device_handlers.device_wrapper.base import DeviceWrapper
+from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
+    FeederSchedule,
+)
 from tuya_device_handlers.registry import DeviceQuirkProtocol, QuirksRegistry
 
 
@@ -57,13 +62,18 @@ class DatapointDefinition:
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
+    _datapoint_definitions: dict[tuple[int, str], DatapointDefinition | None]
+    _get_wrapper_functions: dict[
+        str,
+        Callable[[CustomerDevice], DeviceWrapper | None],
+    ]
+
     def __init__(self) -> None:
         """Initialize the quirk."""
         self._applies_to: list[str] = []
 
-        self._datapoint_definitions: dict[
-            tuple[int, str], DatapointDefinition | None
-        ] = {}
+        self._datapoint_definitions = {}
+        self._get_wrapper_functions = {}
 
         current_frame = inspect.currentframe()
         if TYPE_CHECKING:
@@ -206,3 +216,24 @@ class DeviceQuirk(DeviceQuirkProtocol):
         """Remove datapoint definition."""
         self._datapoint_definitions[(dpid, dpcode)] = None
         return self
+
+    def map_feeder_schedules_wrapper(
+        self,
+        *,
+        wrapper_function: Callable[
+            [CustomerDevice], DeviceWrapper[list[FeederSchedule]] | None
+        ],
+    ) -> Self:
+        """Map feeder schedule service."""
+        self._get_wrapper_functions["feeder_schedules"] = wrapper_function
+        return self
+
+    def get_feeder_schedules_wrapper(
+        self, device: CustomerDevice
+    ) -> DeviceWrapper[list[FeederSchedule]] | None:
+        if get_wrapper_function := self._get_wrapper_functions.get(
+            "feeder_schedules"
+        ):
+            return get_wrapper_function(device)
+
+        return None

--- a/src/tuya_device_handlers/device_wrapper/service_feeder_schedule.py
+++ b/src/tuya_device_handlers/device_wrapper/service_feeder_schedule.py
@@ -25,7 +25,7 @@ class FeederSchedule(TypedDict):
     """True or False."""
 
 
-class _DefaultFeederScheduleWrapper(DPCodeRawWrapper[list[FeederSchedule]]):
+class DefaultFeederScheduleWrapper(DPCodeRawWrapper[list[FeederSchedule]]):
     """Wrapper for a schedule received in a base64 DPCode."""
 
     def __init__(
@@ -71,8 +71,14 @@ class _DefaultFeederScheduleWrapper(DPCodeRawWrapper[list[FeederSchedule]]):
 def get_feeder_schedule_wrapper(
     device: CustomerDevice,
 ) -> DeviceWrapper[list[FeederSchedule]] | None:
+    from tuya_device_handlers import TUYA_QUIRKS_REGISTRY  # noqa: PLC0415
+
+    if (quirk := TUYA_QUIRKS_REGISTRY.get_quirk_for_device(device)) is not None:
+        return quirk.get_feeder_schedules_wrapper(device)
+
+    # Fallback for devices that haven't been added to the registry yet
     if device.product_id == "wfkzyy0evslzsmoi":
-        return _DefaultFeederScheduleWrapper.find_dpcode(
+        return DefaultFeederScheduleWrapper.find_dpcode(
             device, "meal_plan", prefer_function=True
         )
     return None

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -6,6 +6,11 @@ from typing import Any, Protocol, Self
 
 from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
+from tuya_device_handlers.device_wrapper.base import DeviceWrapper
+from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
+    FeederSchedule,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -22,6 +27,10 @@ class DeviceQuirkProtocol(Protocol):
     def quirk_file_line(self) -> int: ...
 
     def initialise_device(self, device: CustomerDevice) -> None: ...
+
+    def get_feeder_schedules_wrapper(
+        self, device: CustomerDevice
+    ) -> DeviceWrapper[list[FeederSchedule]] | None: ...
 
 
 class QuirksRegistry:

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -30,7 +30,8 @@ class DeviceQuirkProtocol(Protocol):
 
     def get_feeder_schedules_wrapper(
         self, device: CustomerDevice
-    ) -> DeviceWrapper[list[FeederSchedule]] | None: ...
+    ) -> DeviceWrapper[list[FeederSchedule]] | None:
+        raise NotImplementedError
 
 
 class QuirksRegistry:

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -30,8 +30,7 @@ class DeviceQuirkProtocol(Protocol):
 
     def get_feeder_schedules_wrapper(
         self, device: CustomerDevice
-    ) -> DeviceWrapper[list[FeederSchedule]] | None:
-        raise NotImplementedError
+    ) -> DeviceWrapper[list[FeederSchedule]] | None: ...
 
 
 class QuirksRegistry:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test fixtures"""
 
-from unittest.mock import Mock
+from collections.abc import Generator
+from unittest.mock import Mock, patch
 
 import pytest
 from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
@@ -8,6 +9,13 @@ from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_device_handlers.registry import QuirksRegistry
+
+
+@pytest.fixture(autouse=True)
+def auto_reset_quirks() -> Generator[None]:
+    """Ensure that quirks are reset before each test."""
+    with patch.dict(TUYA_QUIRKS_REGISTRY._quirks):
+        yield
 
 
 @pytest.fixture(scope="module")

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -182,3 +182,27 @@ def test_get_quirk_feeder_schedule_wrapper(mock_device: CustomerDevice) -> None:
 
     wrapper = get_feeder_schedule_wrapper(mock_device)
     assert isinstance(wrapper, DefaultFeederScheduleWrapper)
+
+
+def test_get_quirk_feeder_schedule_wrapper_unknown(
+    mock_device: CustomerDevice,
+) -> None:
+    """Test get_feeder_schedule_wrapper returns the quirk wrapper."""
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert wrapper is None
+
+    (
+        DeviceQuirk()
+        .applies_to(product_id=mock_device.product_id)
+        .map_feeder_schedules_wrapper(
+            wrapper_function=lambda device: (
+                DefaultFeederScheduleWrapper.find_dpcode(
+                    device, "invalid", prefer_function=True
+                )
+            )
+        )
+        .register(TUYA_QUIRKS_REGISTRY)
+    )
+
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert wrapper is None

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -148,22 +148,6 @@ def test_get_update_commands(
     assert commands == [{"code": dpcode, "value": expected_value}]
 
 
-def test_get_feeder_schedule_wrapper() -> None:
-    """Test get_feeder_schedule_wrapper returns the correct wrapper."""
-    # From fallback in get_feeder_schedule_wrapper
-    assert isinstance(
-        get_feeder_schedule_wrapper(
-            create_device("cwwsq_wfkzyy0evslzsmoi.json")
-        ),
-        DefaultFeederScheduleWrapper,
-    )
-
-    # Not available for this device
-    assert (
-        get_feeder_schedule_wrapper(create_device("cl_zah67ekd.json"))
-    ) is None
-
-
 def test_get_feeder_schedule_wrapper_unknown() -> None:
     """Test get_feeder_schedule_wrapper returns no wrapper."""
     device = create_device("cl_zah67ekd.json")

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -2,7 +2,10 @@
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tuya_sharing import CustomerDevice
 
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder.device_quirk import DeviceQuirk
 from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
     DefaultFeederScheduleWrapper,
     FeederSchedule,
@@ -145,21 +148,53 @@ def test_get_update_commands(
     assert commands == [{"code": dpcode, "value": expected_value}]
 
 
-@pytest.mark.parametrize(
-    ("fixture_filename", "wrapper_type"),
-    [
-        ("cwwsq_wfkzyy0evslzsmoi.json", DefaultFeederScheduleWrapper),
-        ("cl_zah67ekd.json", None),
-    ],
-)
-def test_get_feeder_schedule_wrapper(
-    fixture_filename: str, wrapper_type: type | None
-) -> None:
+def test_get_feeder_schedule_wrapper() -> None:
     """Test get_feeder_schedule_wrapper returns the correct wrapper."""
-    device = create_device(fixture_filename)
+    # From fallback in get_feeder_schedule_wrapper
+    assert isinstance(
+        get_feeder_schedule_wrapper(
+            create_device("cwwsq_wfkzyy0evslzsmoi.json")
+        ),
+        DefaultFeederScheduleWrapper,
+    )
 
+    # Not available for this device
+    assert (
+        get_feeder_schedule_wrapper(create_device("cl_zah67ekd.json"))
+    ) is None
+
+
+def test_get_feeder_schedule_wrapper_unknown() -> None:
+    """Test get_feeder_schedule_wrapper returns no wrapper."""
+    device = create_device("cl_zah67ekd.json")
     wrapper = get_feeder_schedule_wrapper(device)
-    if wrapper_type is None:
-        assert wrapper is None
-    else:
-        assert isinstance(wrapper, wrapper_type)
+    assert wrapper is None
+
+
+def test_get_fallback_feeder_schedule_wrapper() -> None:
+    """Test get_feeder_schedule_wrapper returns the fallback wrapper."""
+    device = create_device("cwwsq_wfkzyy0evslzsmoi.json")
+    wrapper = get_feeder_schedule_wrapper(device)
+    assert isinstance(wrapper, DefaultFeederScheduleWrapper)
+
+
+def test_get_quirk_feeder_schedule_wrapper(mock_device: CustomerDevice) -> None:
+    """Test get_feeder_schedule_wrapper returns the quirk wrapper."""
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert wrapper is None
+
+    (
+        DeviceQuirk()
+        .applies_to(product_id=mock_device.product_id)
+        .map_feeder_schedules_wrapper(
+            wrapper_function=lambda device: (
+                DefaultFeederScheduleWrapper.find_dpcode(
+                    device, "demo_raw", prefer_function=True
+                )
+            )
+        )
+        .register(TUYA_QUIRKS_REGISTRY)
+    )
+
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert isinstance(wrapper, DefaultFeederScheduleWrapper)

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -184,7 +184,7 @@ def test_get_quirk_feeder_schedule_wrapper(mock_device: CustomerDevice) -> None:
     assert isinstance(wrapper, DefaultFeederScheduleWrapper)
 
 
-def test_get_quirk_feeder_schedule_wrapper_unknown(
+def test_get_quirk_feeder_schedule_wrapper_invalid(
     mock_device: CustomerDevice,
 ) -> None:
     """Test get_feeder_schedule_wrapper returns the quirk wrapper."""
@@ -201,6 +201,23 @@ def test_get_quirk_feeder_schedule_wrapper_unknown(
                 )
             )
         )
+        .register(TUYA_QUIRKS_REGISTRY)
+    )
+
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert wrapper is None
+
+
+def test_get_quirk_feeder_schedule_wrapper_not_set(
+    mock_device: CustomerDevice,
+) -> None:
+    """Test get_feeder_schedule_wrapper returns the quirk wrapper."""
+    wrapper = get_feeder_schedule_wrapper(mock_device)
+    assert wrapper is None
+
+    (
+        DeviceQuirk()
+        .applies_to(product_id=mock_device.product_id)
         .register(TUYA_QUIRKS_REGISTRY)
     )
 

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -4,6 +4,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
+    DefaultFeederScheduleWrapper,
     FeederSchedule,
     get_feeder_schedule_wrapper,
 )
@@ -112,17 +113,11 @@ def test_read_device_status(
     device = create_device(fixture_filename)
     device.status["meal_plan"] = data
 
-    wrapper = get_feeder_schedule_wrapper(device)
+    wrapper = DefaultFeederScheduleWrapper.find_dpcode(
+        device, "meal_plan", prefer_function=True
+    )
     assert wrapper is not None
     assert wrapper.read_device_status(device) == snapshot
-
-
-def test_no_wrapper() -> None:
-    """Test wrapper returns None for unsupported devices."""
-    device = create_device("cl_zah67ekd.json")
-
-    wrapper = get_feeder_schedule_wrapper(device)
-    assert wrapper is None
 
 
 @pytest.mark.parametrize(
@@ -141,8 +136,30 @@ def test_get_update_commands(
     """Test get_update_commands encodes data correctly."""
     device = create_device(fixture_filename)
 
-    wrapper = get_feeder_schedule_wrapper(device)
+    wrapper = DefaultFeederScheduleWrapper.find_dpcode(
+        device, "meal_plan", prefer_function=True
+    )
     assert wrapper is not None
 
     commands = wrapper.get_update_commands(device, _SAMPLE_MEAL_PLAN)
     assert commands == [{"code": dpcode, "value": expected_value}]
+
+
+@pytest.mark.parametrize(
+    ("fixture_filename", "wrapper_type"),
+    [
+        ("cwwsq_wfkzyy0evslzsmoi.json", DefaultFeederScheduleWrapper),
+        ("cl_zah67ekd.json", None),
+    ],
+)
+def test_get_feeder_schedule_wrapper(
+    fixture_filename: str, wrapper_type: type | None
+) -> None:
+    """Test get_feeder_schedule_wrapper returns the correct wrapper."""
+    device = create_device(fixture_filename)
+
+    wrapper = get_feeder_schedule_wrapper(device)
+    if wrapper_type is None:
+        assert wrapper is None
+    else:
+        assert isinstance(wrapper, wrapper_type)


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

The current implementation relies on a hard-code list of product ids.
This refactors the implementation so that quirk can register their own wrapper mapping

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
