### PR TITLE
 Expand ruff to select = ALL and enable more pylint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ ignore = [
     "FBT002",  # Boolean default value positional argument
     "FBT003",  # Boolean positional value in call
     "PLR0913", # Too many arguments in function definition
+    "PYI041",  # Redundant numeric union (int is subtype of float, but keep for clarity)
     "RUF012",  # Mutable class default
     "TC006",   # Runtime cast value (stylistic, prefer unquoted)
     "TRY003",  # Raise vanilla args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,20 +71,11 @@ max-attributes = 15
 [tool.pylint."MESSAGES CONTROL"]
 disable = [
     "abstract-method",
-    "arguments-differ",
-    "invalid-name",
-    "broad-exception-caught",
     "cyclic-import",
     "duplicate-code",
     "format",
-    "import-outside-toplevel",
-    "missing-class-docstring",
-    "missing-function-docstring",
-    "redefined-builtin",
     "too-many-arguments",
     "too-many-boolean-expressions",
-    "too-many-positional-arguments",
-    "too-many-return-statements",
     "unsubscriptable-object",
     "unused-argument",
 ]
@@ -104,34 +95,38 @@ target-version = "py313"
 
 [tool.ruff.lint]
 ignore = [
-    "A001",    # Variable is shadowing a Python builtin
-    "A002",    # Argument is shadowing a Python builtin
-    "C400",    # Unnecessary generator
-    "E501",    # Line too long (81 > 80)
-    "ERA001",  # Found commented-out code
-    "N815",    # Variable in class scope should not be mixedCase
-    "PLR2004", # Magic value used in comparison, consider replacing
-    "PLR0911", # Too many return statements
+    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
+    "D203",    # Conflicts with other rules
+    "D213",    # Conflicts with other rules
+    "D417",    # False positives in some occasions
+    "PLR2004", # Magic value used in comparison
+
+    # Conflicts with the Ruff formatter
+    "COM812",
+    "ISC001",
+
+
+    # Pre-existing patterns (can be tightened over time)
+    "ARG002",  # Unused method argument
+    "FBT001",  # Boolean type hint positional argument
+    "FBT002",  # Boolean default value positional argument
+    "FBT003",  # Boolean positional value in call
     "PLR0913", # Too many arguments in function definition
-    "PT001",   # Use `@pytest.fixture()` over `@pytest.fixture`
-    "PT018",   # Assertion should be broken down into multiple parts
-    "PT022",   # No teardown in fixture `cli_runner`, use `return` instead of `yield`
-    "PT023",   # Use `@pytest.mark.asyncio()` over `@pytest.mark.asyncio`
-    "PLW0127", # Self-assignment of variable
+    "RUF012",  # Mutable class default
+    "TC006",   # Runtime cast value (stylistic, prefer unquoted)
+    "TRY003",  # Raise vanilla args
 ]
-select = [
-    "A", #flake8-builtins
-    "B", #flake8-bugbear
-    "C4", #flake8-comprehensions
-    "C90", #mccabe
-    "E", #pycodestyle error
-    "ERA", #eradicate
-    "F", #Pyflakes
-    "I", #isort
-    "N", #pep8-naming
-    "PL", #Pylint
-    "PT", #flake8-pytest-style
-    "UP", #pyupgrade
+select = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "A002",    # Argument shadowing a Python builtin
+    "S101",    # assert
+    "SLF001",  # Private member access
+    "PT018",   # Composite assertion
+    "PTH123",  # builtin open
+    "PTH207",  # glob
+    "S108",    # Hardcoded temp file
 ]
 
 [tool.ruff.lint.isort]

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -141,7 +141,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Set the device type the quirk applies to."""
         if self._applies_to is not None:
-            raise ValueError("DeviceQuirk already has an applies_to condition")
+            msg = "DeviceQuirk already has an applies_to condition"
+            raise ValueError(msg)
         self._applies_to = product_id
         self.manufacturer = manufacturer
         self.model = model
@@ -151,9 +152,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
     def register(self, registry: QuirksRegistry) -> None:
         """Register the quirk in the registry."""
         if self._applies_to is None:
-            raise ValueError(
-                "DeviceQuirk does not have an applies_to condition"
-            )
+            msg = "DeviceQuirk does not have an applies_to condition"
+            raise ValueError(msg)
         registry.register(self._applies_to, self)
 
     def add_dpid_bitmap(
@@ -202,8 +202,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
         dpcode: str,
         dpmode: DPMode,
         unit: str,
-        min: int,
-        max: int,
+        min: int,  # noqa: A002  # pylint: disable=redefined-builtin
+        max: int,  # noqa: A002  # pylint: disable=redefined-builtin
         scale: int,
         step: int,
         report_type: str | None = None,
@@ -246,6 +246,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     def get_feeder_schedules_wrapper(
         self, device: CustomerDevice
     ) -> DeviceWrapper[list[FeederSchedule]] | None:
+        """Get the feeder schedules wrapper for a device."""
         if get_wrapper_function := self._get_wrapper_functions.get(
             "feeder_schedules"
         ):

--- a/src/tuya_device_handlers/const.py
+++ b/src/tuya_device_handlers/const.py
@@ -33,6 +33,7 @@ class DPType(StrEnum):
 
     @staticmethod
     def try_parse(current_type: str) -> DPType | None:
+        """Try to parse a string into a DPType."""
         try:
             return DPType(current_type)
         except ValueError:

--- a/src/tuya_device_handlers/definition/alarm_control_panel.py
+++ b/src/tuya_device_handlers/definition/alarm_control_panel.py
@@ -5,22 +5,25 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.alarm_control_panel import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.alarm_control_panel import (
     AlarmActionWrapper,
     AlarmChangedByWrapper,
     AlarmStateWrapper,
 )
-from ..helpers.homeassistant import (
+from tuya_device_handlers.helpers.homeassistant import (
     TuyaAlarmControlPanelAction,
     TuyaAlarmControlPanelState,
 )
-from ..type_information import EnumTypeInformation
+from tuya_device_handlers.type_information import EnumTypeInformation
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class AlarmControlPanelDefinition:
+    """Definition for an alarm control panel entity."""
+
     action_wrapper: DeviceWrapper[TuyaAlarmControlPanelAction]
     changed_by_wrapper: DeviceWrapper[str] | None
     state_wrapper: DeviceWrapper[TuyaAlarmControlPanelState]
@@ -39,6 +42,7 @@ class AlarmControlPanelQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice,
 ) -> AlarmControlPanelDefinition | None:
+    """Get the default alarm control panel definition for a device."""
     if not (
         master_mode := EnumTypeInformation.find_dpcode(
             device, "master_mode", prefer_function=True

--- a/src/tuya_device_handlers/definition/binary_sensor.py
+++ b/src/tuya_device_handlers/definition/binary_sensor.py
@@ -5,17 +5,20 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.binary_sensor import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.binary_sensor import (
     DPCodeBitmapBitWrapper,
     DPCodeInSetWrapper,
 )
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class BinarySensorDefinition:
+    """Definition for a binary sensor entity."""
+
     binary_sensor_wrapper: DeviceWrapper[bool]
 
 
@@ -33,8 +36,9 @@ def get_default_definition(
     device: CustomerDevice,
     dpcode: str,
     bitmap_key: str | None = None,
-    on_value: bool | float | int | str | set[bool | float | int | str] = True,
+    on_value: bool | float | str | set[bool | float | int | str] = True,
 ) -> BinarySensorDefinition | None:
+    """Get the default binary sensor definition for a device."""
     if bitmap_key is not None:
         if bitmap_wrapper := DPCodeBitmapBitWrapper.find_dpcode(
             device, dpcode, bitmap_key=bitmap_key

--- a/src/tuya_device_handlers/definition/binary_sensor.py
+++ b/src/tuya_device_handlers/definition/binary_sensor.py
@@ -36,7 +36,7 @@ def get_default_definition(
     device: CustomerDevice,
     dpcode: str,
     bitmap_key: str | None = None,
-    on_value: bool | float | str | set[bool | float | int | str] = True,
+    on_value: bool | float | int | str | set[bool | float | int | str] = True,
 ) -> BinarySensorDefinition | None:
     """Get the default binary sensor definition for a device."""
     if bitmap_key is not None:

--- a/src/tuya_device_handlers/definition/button.py
+++ b/src/tuya_device_handlers/definition/button.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class ButtonDefinition:
+    """Definition for a button entity."""
+
     button_wrapper: DeviceWrapper[bool]
 
 
@@ -28,6 +31,7 @@ class ButtonQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> ButtonDefinition | None:
+    """Get the default button definition for a device."""
     if wrapper := DPCodeBooleanWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/definition/camera.py
+++ b/src/tuya_device_handlers/definition/camera.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class CameraDefinition:
+    """Definition for a camera entity."""
+
     motion_detection_switch: DeviceWrapper[bool] | None
     recording_status: DeviceWrapper[bool] | None
 
@@ -27,6 +30,7 @@ class CameraQuirk(BaseEntityQuirk):
 
 
 def get_default_definition(device: CustomerDevice) -> CameraDefinition:
+    """Get the default camera definition for a device."""
     return CameraDefinition(
         motion_detection_switch=DPCodeBooleanWrapper.find_dpcode(
             device, "motion_switch", prefer_function=True

--- a/src/tuya_device_handlers/definition/climate.py
+++ b/src/tuya_device_handlers/definition/climate.py
@@ -5,29 +5,34 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..const import CELSIUS_ALIASES, FAHRENHEIT_ALIASES
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.climate import (
+from tuya_device_handlers.const import CELSIUS_ALIASES, FAHRENHEIT_ALIASES
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.climate import (
     DefaultHVACModeWrapper,
     DefaultPresetModeWrapper,
     SwingModeCompositeWrapper,
 )
-from ..device_wrapper.common import (
+from tuya_device_handlers.device_wrapper.common import (
     DPCodeBooleanWrapper,
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
 )
-from ..device_wrapper.extended import DPCodeRoundedIntegerWrapper
-from ..helpers.homeassistant import (
+from tuya_device_handlers.device_wrapper.extended import (
+    DPCodeRoundedIntegerWrapper,
+)
+from tuya_device_handlers.helpers.homeassistant import (
     TuyaClimateHVACMode,
     TuyaClimateSwingMode,
     TuyaUnitOfTemperature,
 )
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class ClimateDefinition:
+    """Definition for a climate entity."""
+
     current_humidity_wrapper: DeviceWrapper[int] | None
     current_temperature_wrapper: DeviceWrapper[float] | None
     fan_mode_wrapper: DeviceWrapper[str] | None
@@ -95,7 +100,7 @@ def get_temperature_wrappers(
     )
 
     # Return early if we have the right wrappers for the system unit
-    if system_temperature_unit == TuyaUnitOfTemperature.FAHRENHEIT:
+    if system_temperature_unit == TuyaUnitOfTemperature.FAHRENHEIT:  # noqa: SIM102
         if (
             (current_fahrenheit and set_fahrenheit)
             or (current_fahrenheit and not set_celsius)
@@ -175,6 +180,7 @@ def _get_default_temperature_wrappers(
 def get_default_definition(
     device: CustomerDevice, system_temperature_unit: TuyaUnitOfTemperature
 ) -> ClimateDefinition:
+    """Get the default climate definition for a device."""
     current_temperature_wrapper, set_temperature_wrapper, temperature_unit = (
         _get_default_temperature_wrappers(device, system_temperature_unit)
     )

--- a/src/tuya_device_handlers/definition/cover.py
+++ b/src/tuya_device_handlers/definition/cover.py
@@ -5,20 +5,27 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeTypeInformationWrapper
-from ..device_wrapper.cover import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
+    DPCodeTypeInformationWrapper,
+)
+from tuya_device_handlers.device_wrapper.cover import (
     CoverClosedEnumWrapper,
     CoverInstructionBooleanWrapper,
     CoverInstructionEnumWrapper,
 )
-from ..device_wrapper.extended import DPCodeInvertedPercentageWrapper
-from ..helpers.homeassistant import TuyaCoverAction
+from tuya_device_handlers.device_wrapper.extended import (
+    DPCodeInvertedPercentageWrapper,
+)
+from tuya_device_handlers.helpers.homeassistant import TuyaCoverAction
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class CoverDefinition:
+    """Definition for a cover entity."""
+
     current_position_wrapper: DeviceWrapper[int] | None
     current_state_wrapper: DeviceWrapper[bool] | None
     instruction_wrapper: DeviceWrapper[TuyaCoverAction] | None
@@ -53,6 +60,7 @@ def get_default_definition(
         DPCodeTypeInformationWrapper
     ] = DPCodeInvertedPercentageWrapper,
 ) -> CoverDefinition | None:
+    """Get the default cover definition for a device."""
     if not (
         instruction_dpcode in device.function
         or instruction_dpcode in device.status_range

--- a/src/tuya_device_handlers/definition/event.py
+++ b/src/tuya_device_handlers/definition/event.py
@@ -6,14 +6,19 @@ from typing import Any
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeTypeInformationWrapper
-from ..device_wrapper.event import SimpleEventEnumWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
+    DPCodeTypeInformationWrapper,
+)
+from tuya_device_handlers.device_wrapper.event import SimpleEventEnumWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class EventDefinition:
+    """Definition for an event entity."""
+
     event_wrapper: DeviceWrapper[tuple[str, dict[str, Any] | None]]
 
 
@@ -32,6 +37,7 @@ def get_default_definition(
     dpcode: str,
     wrapper_class: type[DPCodeTypeInformationWrapper] = SimpleEventEnumWrapper,
 ) -> EventDefinition | None:
+    """Get the default event definition for a device."""
     if wrapper := wrapper_class.find_dpcode(device, dpcode):
         return EventDefinition(
             event_wrapper=wrapper,

--- a/src/tuya_device_handlers/definition/fan.py
+++ b/src/tuya_device_handlers/definition/fan.py
@@ -5,19 +5,25 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper, DPCodeEnumWrapper
-from ..device_wrapper.fan import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
+    DPCodeBooleanWrapper,
+    DPCodeEnumWrapper,
+)
+from tuya_device_handlers.device_wrapper.fan import (
     FanDirectionEnumWrapper,
     FanSpeedEnumWrapper,
     FanSpeedIntegerWrapper,
 )
-from ..helpers.homeassistant import TuyaFanDirection
+from tuya_device_handlers.helpers.homeassistant import TuyaFanDirection
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class FanDefinition:
+    """Definition for a fan entity."""
+
     direction_wrapper: DeviceWrapper[TuyaFanDirection] | None
     mode_wrapper: DeviceWrapper[str] | None
     oscillate_wrapper: DeviceWrapper[bool] | None
@@ -43,6 +49,7 @@ _SWITCH_DPCODES = ("switch_fan", "fan_switch", "switch")
 
 
 def get_default_definition(device: CustomerDevice) -> FanDefinition | None:
+    """Get the default fan definition for a device."""
     properties_to_check: set[str] = {
         # Main control switch
         *_SWITCH_DPCODES,

--- a/src/tuya_device_handlers/definition/humidifier.py
+++ b/src/tuya_device_handlers/definition/humidifier.py
@@ -5,14 +5,22 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper, DPCodeEnumWrapper
-from ..device_wrapper.extended import DPCodeRoundedIntegerWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
+    DPCodeBooleanWrapper,
+    DPCodeEnumWrapper,
+)
+from tuya_device_handlers.device_wrapper.extended import (
+    DPCodeRoundedIntegerWrapper,
+)
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class HumidifierDefinition:
+    """Definition for a humidifier entity."""
+
     current_humidity_wrapper: DeviceWrapper[int] | None = None
     mode_wrapper: DeviceWrapper[str] | None = None
     switch_wrapper: DeviceWrapper[bool] | None = None
@@ -36,6 +44,7 @@ def get_default_definition(
     current_humidity_dpcode: str | None = None,
     humidity_dpcode: str | None = None,
 ) -> HumidifierDefinition | None:
+    """Get the default humidifier definition for a device."""
     properties_to_check: set[str | None] = {
         # Main control switch
         *(

--- a/src/tuya_device_handlers/definition/light.py
+++ b/src/tuya_device_handlers/definition/light.py
@@ -8,13 +8,13 @@ from typing import Any, cast
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
     DPCodeBooleanWrapper,
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
 )
-from ..device_wrapper.light import (
+from tuya_device_handlers.device_wrapper.light import (
     DEFAULT_H_TYPE_V2,
     DEFAULT_S_TYPE_V2,
     DEFAULT_V_TYPE_V2,
@@ -22,12 +22,15 @@ from ..device_wrapper.light import (
     ColorDataWrapper,
     ColorTempWrapper,
 )
-from ..utils import RemapHelper
+from tuya_device_handlers.utils import RemapHelper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class LightDefinition:
+    """Definition for a light entity."""
+
     brightness_wrapper: DeviceWrapper[int] | None
     color_data_wrapper: DeviceWrapper[tuple[float, float, float]] | None
     color_mode_wrapper: DeviceWrapper[str] | None
@@ -66,6 +69,7 @@ def get_default_definition(
     color_temp_dpcode: str | tuple[str, ...] | None = None,
     fallback_color_data_mode: FallbackColorDataMode = FallbackColorDataMode.V1,
 ) -> LightDefinition | None:
+    """Get the default light definition for a device."""
     if not (
         switch_wrapper := DPCodeBooleanWrapper.find_dpcode(
             device, switch_dpcode, prefer_function=True

--- a/src/tuya_device_handlers/definition/number.py
+++ b/src/tuya_device_handlers/definition/number.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeIntegerWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeIntegerWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class NumberDefinition:
+    """Definition for a number entity."""
+
     number_wrapper: DeviceWrapper[float]
 
 
@@ -28,6 +31,7 @@ class NumberQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> NumberDefinition | None:
+    """Get the default number definition for a device."""
     if wrapper := DPCodeIntegerWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/definition/select.py
+++ b/src/tuya_device_handlers/definition/select.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeEnumWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeEnumWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class SelectDefinition:
+    """Definition for a select entity."""
+
     select_wrapper: DeviceWrapper[str]
 
 
@@ -28,6 +31,7 @@ class SelectQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> SelectDefinition | None:
+    """Get the default select definition for a device."""
     if wrapper := DPCodeEnumWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/definition/sensor.py
+++ b/src/tuya_device_handlers/definition/sensor.py
@@ -5,19 +5,22 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import (
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import (
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
     DPCodeTypeInformationWrapper,
 )
-from ..device_wrapper.sensor import DeltaIntegerWrapper
-from ..type_information import IntegerTypeInformation
+from tuya_device_handlers.device_wrapper.sensor import DeltaIntegerWrapper
+from tuya_device_handlers.type_information import IntegerTypeInformation
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class SensorDefinition:
+    """Definition for a sensor entity."""
+
     sensor_wrapper: DeviceWrapper[str | int | float]
 
 

--- a/src/tuya_device_handlers/definition/siren.py
+++ b/src/tuya_device_handlers/definition/siren.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class SirenDefinition:
+    """Definition for a siren entity."""
+
     siren_wrapper: DeviceWrapper[bool]
 
 
@@ -28,6 +31,7 @@ class SirenQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> SirenDefinition | None:
+    """Get the default siren definition for a device."""
     if wrapper := DPCodeBooleanWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/definition/switch.py
+++ b/src/tuya_device_handlers/definition/switch.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class SwitchDefinition:
+    """Definition for a switch entity."""
+
     switch_wrapper: DeviceWrapper[bool]
 
 
@@ -28,6 +31,7 @@ class SwitchQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> SwitchDefinition | None:
+    """Get the default switch definition for a device."""
     if wrapper := DPCodeBooleanWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/definition/vacuum.py
+++ b/src/tuya_device_handlers/definition/vacuum.py
@@ -5,15 +5,24 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeEnumWrapper
-from ..device_wrapper.vacuum import VacuumActionWrapper, VacuumActivityWrapper
-from ..helpers.homeassistant import TuyaVacuumAction, TuyaVacuumActivity
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeEnumWrapper
+from tuya_device_handlers.device_wrapper.vacuum import (
+    VacuumActionWrapper,
+    VacuumActivityWrapper,
+)
+from tuya_device_handlers.helpers.homeassistant import (
+    TuyaVacuumAction,
+    TuyaVacuumActivity,
+)
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class VacuumDefinition:
+    """Definition for a vacuum entity."""
+
     action_wrapper: DeviceWrapper[TuyaVacuumAction] | None
     activity_wrapper: DeviceWrapper[TuyaVacuumActivity] | None
     fan_speed_wrapper: DeviceWrapper[str] | None
@@ -30,6 +39,7 @@ class VacuumQuirk(BaseEntityQuirk):
 
 
 def get_default_definition(device: CustomerDevice) -> VacuumDefinition:
+    """Get the default vacuum definition for a device."""
     return VacuumDefinition(
         action_wrapper=VacuumActionWrapper.find_dpcode(device),
         activity_wrapper=VacuumActivityWrapper.find_dpcode(device),

--- a/src/tuya_device_handlers/definition/valve.py
+++ b/src/tuya_device_handlers/definition/valve.py
@@ -5,13 +5,16 @@ from dataclasses import dataclass
 
 from tuya_sharing import CustomerDevice
 
-from ..device_wrapper import DeviceWrapper
-from ..device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.device_wrapper import DeviceWrapper
+from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+
 from .base import BaseEntityQuirk
 
 
 @dataclass(kw_only=True)
 class ValveDefinition:
+    """Definition for a valve entity."""
+
     control_wrapper: DeviceWrapper[bool]
 
 
@@ -28,6 +31,7 @@ class ValveQuirk(BaseEntityQuirk):
 def get_default_definition(
     device: CustomerDevice, dpcode: str
 ) -> ValveDefinition | None:
+    """Get the default valve definition for a device."""
     if wrapper := DPCodeBooleanWrapper.find_dpcode(
         device, dpcode, prefer_function=True
     ):

--- a/src/tuya_device_handlers/device_wrapper/alarm_control_panel.py
+++ b/src/tuya_device_handlers/device_wrapper/alarm_control_panel.py
@@ -5,11 +5,12 @@ from typing import Any
 
 from tuya_sharing import CustomerDevice
 
-from ..helpers.homeassistant import (
+from tuya_device_handlers.helpers.homeassistant import (
     TuyaAlarmControlPanelAction,
     TuyaAlarmControlPanelState,
 )
-from ..type_information import EnumTypeInformation
+from tuya_device_handlers.type_information import EnumTypeInformation
+
 from .common import DPCodeEnumWrapper, DPCodeRawWrapper
 
 
@@ -49,9 +50,10 @@ class AlarmStateWrapper(DPCodeEnumWrapper[TuyaAlarmControlPanelState]):
         self, device: CustomerDevice
     ) -> TuyaAlarmControlPanelState | None:
         """Read the device status."""
-        # When the alarm is triggered, only its 'state' is changing. From 'normal' to 'alarm'.
+        # When the alarm is triggered, only its 'state' is
+        # changing. From 'normal' to 'alarm'.
         # The 'mode' doesn't change, and stays as 'arm' or 'home'.
-        if device.status.get("master_state") == "alarm":
+        if device.status.get("master_state") == "alarm":  # noqa: SIM102
             # Only report as triggered if NOT a battery warning
             if not (
                 (encoded_msg := device.status.get("alarm_msg"))
@@ -97,4 +99,5 @@ class AlarmActionWrapper(DPCodeEnumWrapper[TuyaAlarmControlPanelAction]):
         """Convert value to raw value."""
         if value in self.options:
             return self._ACTION_MAPPINGS[value]
-        raise ValueError(f"Unsupported value {value} for {self.dpcode}")
+        msg = f"Unsupported value {value} for {self.dpcode}"
+        raise ValueError(msg)

--- a/src/tuya_device_handlers/device_wrapper/binary_sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/binary_sensor.py
@@ -4,7 +4,8 @@ from typing import Self
 
 from tuya_sharing import CustomerDevice
 
-from ..type_information import BitmapTypeInformation
+from tuya_device_handlers.type_information import BitmapTypeInformation
+
 from .common import DPCodeBitmapWrapper, DPCodeWrapper
 
 
@@ -25,7 +26,7 @@ class DPCodeBitmapBitWrapper(DPCodeBitmapWrapper[bool]):
         return (raw_value & (1 << self._mask)) != 0
 
     @classmethod
-    def find_dpcode(  # ty: ignore[invalid-method-override]
+    def find_dpcode(  # ty: ignore[invalid-method-override]  # pylint: disable=arguments-differ
         cls,
         device: CustomerDevice,
         dpcodes: str | tuple[str, ...] | None,

--- a/src/tuya_device_handlers/device_wrapper/climate.py
+++ b/src/tuya_device_handlers/device_wrapper/climate.py
@@ -6,8 +6,12 @@ from typing import Any, Self
 
 from tuya_sharing import CustomerDevice
 
-from ..helpers.homeassistant import TuyaClimateHVACMode, TuyaClimateSwingMode
-from ..type_information import EnumTypeInformation
+from tuya_device_handlers.helpers.homeassistant import (
+    TuyaClimateHVACMode,
+    TuyaClimateSwingMode,
+)
+from tuya_device_handlers.type_information import EnumTypeInformation
+
 from .base import DeviceWrapper
 from .common import DPCodeBooleanWrapper, DPCodeEnumWrapper
 
@@ -130,10 +134,11 @@ class SwingModeCompositeWrapper(DeviceWrapper[TuyaClimateSwingMode]):
 def _filter_hvac_mode_mappings(
     tuya_range: list[str],
 ) -> dict[str, TuyaClimateHVACMode | None]:
-    """Filter TUYA_HVAC_TO_HA modes that are not in the range.
+    """Filter TUYA_HVAC_TO_HA modes not in the range.
 
-    If multiple Tuya modes map to the same HA mode, set the mapping to None to avoid
-    ambiguity when converting back from HA to Tuya modes.
+    If multiple Tuya modes map to the same HA mode, set the
+    mapping to None to avoid ambiguity when converting back
+    from HA to Tuya modes.
     """
     modes_in_range = {
         tuya_mode: _DEFAULT_DEVICE_MODE_TO_HVACMODE.get(tuya_mode)
@@ -149,7 +154,8 @@ def _filter_hvac_mode_mappings(
 class DefaultHVACModeWrapper(DPCodeEnumWrapper[TuyaClimateHVACMode]):
     """Wrapper for managing climate HVACMode."""
 
-    # Modes that do not map to HVAC modes are ignored (they are handled by PresetWrapper)
+    # Modes that do not map to HVAC modes are ignored
+    # (they are handled by PresetWrapper)
 
     def __init__(
         self, dpcode: str, type_information: EnumTypeInformation
@@ -189,7 +195,8 @@ class DefaultHVACModeWrapper(DPCodeEnumWrapper[TuyaClimateHVACMode]):
 class DefaultPresetModeWrapper(DPCodeEnumWrapper):
     """Wrapper for managing climate preset modes."""
 
-    # Modes that map to HVAC modes are ignored (they are handled by HVACModeWrapper)
+    # Modes that map to HVAC modes are ignored
+    # (they are handled by HVACModeWrapper)
 
     def __init__(
         self, dpcode: str, type_information: EnumTypeInformation

--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 from tuya_sharing import CustomerDevice
 
-from ..type_information import (
+from tuya_device_handlers.type_information import (
     BitmapTypeInformation,
     BooleanTypeInformation,
     EnumTypeInformation,
@@ -14,6 +14,7 @@ from ..type_information import (
     StringTypeInformation,
     TypeInformation,
 )
+
 from .base import DeviceWrapper
 from .exception import SetValueOutOfRangeError
 
@@ -49,8 +50,9 @@ class DPCodeWrapper[T](DeviceWrapper[T]):
     def _read_dpcode_value(self, device: CustomerDevice) -> Any | None:
         """Read the DPCode value.
 
-        Base implementation returns the raw value, subclasses may override to provide
-        specific conversion or validation.
+        Base implementation returns the raw value, subclasses
+        may override to provide specific conversion or
+        validation.
         """
         return device.status.get(self.dpcode)
 
@@ -59,8 +61,8 @@ class DPCodeWrapper[T](DeviceWrapper[T]):
     ) -> Any:
         """Convert display value back to a raw device value.
 
-        Base implementation does no validation, subclasses may override to provide
-        specific validation.
+        Base implementation does no validation, subclasses may
+        override to provide specific validation.
         """
         raise NotImplementedError
 
@@ -102,7 +104,7 @@ class DPCodeTypeInformationWrapper[
         *,
         prefer_function: bool = False,
     ) -> Self | None:
-        """Find and return a DPCodeTypeInformationWrapper for the given DP codes."""
+        """Find a DPCodeTypeInformationWrapper for the given DP codes."""
         if type_information := cls._DPTYPE.find_dpcode(
             device, dpcodes, prefer_function=prefer_function
         ):
@@ -143,7 +145,8 @@ class DPCodeBooleanWrapper[T = bool](
             return value
         # Currently only called with boolean values
         # Safety net in case of future changes
-        raise SetValueOutOfRangeError(f"Invalid boolean value `{value}`")
+        msg = f"Invalid boolean value `{value}`"
+        raise SetValueOutOfRangeError(msg)
 
 
 class DPCodeEnumWrapper[T = str](
@@ -172,9 +175,10 @@ class DPCodeEnumWrapper[T = str](
             return value
         # Guarded by select option validation
         # Safety net in case of future changes
-        raise SetValueOutOfRangeError(
+        msg = (
             f"Enum value `{value}` out of range: {self.type_information.range}"
         )
+        raise SetValueOutOfRangeError(msg)
 
 
 class DPCodeIntegerWrapper[T = float](
@@ -205,10 +209,11 @@ class DPCodeIntegerWrapper[T = float](
             return new_value
         # Guarded by number validation
         # Safety net in case of future changes
-        raise SetValueOutOfRangeError(
+        msg = (
             f"Value `{new_value}` (converted from `{value}`) out of range:"
             f" ({self.type_information.min}-{self.type_information.max})"
         )
+        raise SetValueOutOfRangeError(msg)
 
 
 class DPCodeJsonWrapper[T = dict[str, Any]](

--- a/src/tuya_device_handlers/device_wrapper/cover.py
+++ b/src/tuya_device_handlers/device_wrapper/cover.py
@@ -2,8 +2,9 @@
 
 from tuya_sharing import CustomerDevice
 
-from ..helpers.homeassistant import TuyaCoverAction
-from ..type_information import EnumTypeInformation
+from tuya_device_handlers.helpers.homeassistant import TuyaCoverAction
+from tuya_device_handlers.type_information import EnumTypeInformation
+
 from .common import DPCodeBooleanWrapper, DPCodeEnumWrapper
 from .extended import DPCodePercentageWrapper
 
@@ -50,6 +51,7 @@ class CoverInstructionEnumWrapper(DPCodeEnumWrapper[TuyaCoverAction]):
     def __init__(
         self, dpcode: str, type_information: EnumTypeInformation
     ) -> None:
+        """Initialize CoverInstructionEnumWrapper."""
         super().__init__(dpcode, type_information)
         self.options = [
             ha_action
@@ -84,6 +86,7 @@ class CoverClosedEnumWrapper(DPCodeEnumWrapper[bool]):
     }
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for this datapoint."""
         if (value := self._read_dpcode_value(device)) is None:
             return None
         return self._MAPPINGS.get(value)

--- a/src/tuya_device_handlers/device_wrapper/extended.py
+++ b/src/tuya_device_handlers/device_wrapper/extended.py
@@ -4,8 +4,9 @@ from typing import Any
 
 from tuya_sharing import CustomerDevice
 
-from ..type_information import IntegerTypeInformation
-from ..utils import RemapHelper
+from tuya_device_handlers.type_information import IntegerTypeInformation
+from tuya_device_handlers.utils import RemapHelper
+
 from .common import DPCodeBooleanWrapper, DPCodeIntegerWrapper
 
 
@@ -85,6 +86,7 @@ class DPCodeInvertedBooleanWrapper(DPCodeBooleanWrapper):
     """Inverted boolean wrapper."""
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for this datapoint."""
         if (value := self._read_dpcode_value(device)) is None:
             return None
         return not value

--- a/src/tuya_device_handlers/device_wrapper/fan.py
+++ b/src/tuya_device_handlers/device_wrapper/fan.py
@@ -4,8 +4,12 @@ from typing import Any
 
 from tuya_sharing import CustomerDevice
 
-from ..helpers.homeassistant import TuyaFanDirection
-from ..type_information import EnumTypeInformation, IntegerTypeInformation
+from tuya_device_handlers.helpers.homeassistant import TuyaFanDirection
+from tuya_device_handlers.type_information import (
+    EnumTypeInformation,
+    IntegerTypeInformation,
+)
+
 from .common import DPCodeEnumWrapper
 from .extended import DPCodeRemappedIntegerWrapper
 

--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -5,17 +5,19 @@ from typing import Any
 
 from tuya_sharing import CustomerDevice
 
-from ..type_information import IntegerTypeInformation
-from ..utils import RemapHelper
+from tuya_device_handlers.type_information import IntegerTypeInformation
+from tuya_device_handlers.utils import RemapHelper
+
 from .common import DPCodeIntegerWrapper, DPCodeJsonWrapper
 
 
 class BrightnessWrapper(DPCodeIntegerWrapper[int]):
     """Wrapper for brightness DP code.
 
-    Handles brightness value conversion between device scale and Home Assistant's
-    0-255 scale. Supports optional dynamic brightness_min and brightness_max
-    wrappers that allow the device to specify runtime brightness range limits.
+    Handles brightness value conversion between device scale
+    and Home Assistant's 0-255 scale. Supports optional dynamic
+    brightness_min and brightness_max wrappers that allow the
+    device to specify runtime brightness range limits.
     """
 
     brightness_min: DPCodeIntegerWrapper | None = None
@@ -78,7 +80,7 @@ class BrightnessWrapper(DPCodeIntegerWrapper[int]):
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: float
     ) -> Any:
-        """Convert a Home Assistant value (0..255) back to a raw device value."""
+        """Convert HA value (0..255) to a raw device value."""
         # If there is a min/max value, the brightness is actually limited.
         # Meaning it is actually not on a 0-255 scale.
         if (
@@ -127,10 +129,12 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
 
     @staticmethod
     def kelvin_to_mired(kelvin: int) -> float:
+        """Convert Kelvin to Mired."""
         return 1000000 / kelvin
 
     @staticmethod
     def mired_to_kelvin(mired: float) -> int:
+        """Convert Mired to Kelvin."""
         return round(1000000 / mired)
 
     def __init__(
@@ -156,7 +160,7 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: int
     ) -> Any:
-        """Convert a Home Assistant value (Kelvin) back to a raw device value."""
+        """Convert HA value (Kelvin) to a raw device value."""
         return round(
             self._remap_helper.remap_value_from(
                 self.kelvin_to_mired(value),
@@ -209,7 +213,7 @@ class ColorDataWrapper(DPCodeJsonWrapper[tuple[float, float, float]]):
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: tuple[float, float, float]
     ) -> Any:
-        """Convert a Home Assistant tuple (H, S, V) back to a raw device value."""
+        """Convert HA tuple (H, S, V) to a raw device value."""
         hue, saturation, brightness = value
         return json.dumps(
             {

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -4,7 +4,8 @@ import logging
 
 from tuya_sharing import CustomerDevice
 
-from ..raw_data_model import ElectricityData
+from tuya_device_handlers.raw_data_model import ElectricityData
+
 from .common import (
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
@@ -63,7 +64,8 @@ class DeltaIntegerWrapper(DPCodeIntegerWrapper):
     ) -> bool:
         """Override skip_update to process delta updates.
 
-        Processes delta accumulation before determining if update should be skipped.
+        Processes delta accumulation before determining if
+        update should be skipped.
         """
         if (
             super().skip_update(

--- a/src/tuya_device_handlers/device_wrapper/service_feeder_schedule.py
+++ b/src/tuya_device_handlers/device_wrapper/service_feeder_schedule.py
@@ -13,7 +13,7 @@ from .common import DPCodeRawWrapper
 
 
 class FeederSchedule(TypedDict):
-    """Public class for Home Assistant representation of a feeder schedule entry."""
+    """HA representation of a feeder schedule entry."""
 
     days: list[str]
     """Days (monday-sunday)."""
@@ -31,6 +31,7 @@ class DefaultFeederScheduleWrapper(DPCodeRawWrapper[list[FeederSchedule]]):
     def __init__(
         self, dpcode: str, type_information: RawTypeInformation
     ) -> None:
+        """Initialize DefaultFeederScheduleWrapper."""
         super().__init__(dpcode, type_information)
         template: list[tuple[_TEMPLATE_KEY, int]] = [
             ("days", 2),
@@ -71,7 +72,10 @@ class DefaultFeederScheduleWrapper(DPCodeRawWrapper[list[FeederSchedule]]):
 def get_feeder_schedule_wrapper(
     device: CustomerDevice,
 ) -> DeviceWrapper[list[FeederSchedule]] | None:
-    from tuya_device_handlers import TUYA_QUIRKS_REGISTRY  # noqa: PLC0415
+    """Get the feeder schedules wrapper for a device."""
+    from tuya_device_handlers import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        TUYA_QUIRKS_REGISTRY,
+    )
 
     if (quirk := TUYA_QUIRKS_REGISTRY.get_quirk_for_device(device)) is not None:
         return quirk.get_feeder_schedules_wrapper(device)
@@ -84,8 +88,9 @@ def get_feeder_schedule_wrapper(
     return None
 
 
-# Internal representation of a feeding time entry to keep it easier to tell what we expect.
-_TEMPLATE_KEY = Literal["days", "hour", "minute", "portion", "enabled"]
+# Internal representation of a feeding time entry to keep it
+# easier to tell what we expect.
+_TEMPLATE_KEY = Literal["days", "hour", "minute", "portion", "enabled"]  # pylint: disable=invalid-name
 
 
 class _DaysOfWeek(IntFlag):
@@ -150,18 +155,15 @@ def _internal_list_to_home_assistant(
     Days are converted from bitmap integer to list of day names.
     Time is merged from separate hour and minute integers to "hh:mm" string.
     """
-
-    result: list[FeederSchedule] = []
-    for item in entries:
-        result.append(
-            FeederSchedule(
-                days=[i.name.lower() for i in _DaysOfWeek if item["days"] & i],
-                time=f"{item['hour']:02d}:{item['minute']:02d}",
-                portion=item["portion"],
-                enabled=bool(item["enabled"]),
-            )
+    return [
+        FeederSchedule(
+            days=[i.name.lower() for i in _DaysOfWeek if item["days"] & i],
+            time=f"{item['hour']:02d}:{item['minute']:02d}",
+            portion=item["portion"],
+            enabled=bool(item["enabled"]),
         )
-    return result
+        for item in entries
+    ]
 
 
 class _DayTransformer:
@@ -174,6 +176,7 @@ class _DayTransformer:
     def encode_entry(
         self, entry: _InternalFeederSchedule
     ) -> _InternalFeederSchedule:
+        """Encode day bitmask from internal to device order."""
         val = 0
         for internal, device in self._day_mapping:
             if entry["days"] & (1 << internal):
@@ -184,6 +187,7 @@ class _DayTransformer:
     def decode_entry(
         self, entry: _InternalFeederSchedule
     ) -> _InternalFeederSchedule:
+        """Decode day bitmask from device to internal order."""
         val = _DaysOfWeek(0)
         masked = entry["days"] & 0x7F
         for internal, device in self._day_mapping:

--- a/src/tuya_device_handlers/device_wrapper/vacuum.py
+++ b/src/tuya_device_handlers/device_wrapper/vacuum.py
@@ -4,7 +4,11 @@ from typing import Any, Self
 
 from tuya_sharing import CustomerDevice
 
-from ..helpers.homeassistant import TuyaVacuumAction, TuyaVacuumActivity
+from tuya_device_handlers.helpers.homeassistant import (
+    TuyaVacuumAction,
+    TuyaVacuumActivity,
+)
+
 from .base import DeviceWrapper
 from .common import DPCodeBooleanWrapper, DPCodeEnumWrapper
 
@@ -81,7 +85,7 @@ class VacuumActionWrapper(DeviceWrapper[TuyaVacuumAction]):
 
     _TUYA_MODE_RETURN_HOME = "chargego"
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         charge_wrapper: DPCodeBooleanWrapper | None,
         locate_wrapper: DPCodeBooleanWrapper | None,
@@ -127,7 +131,7 @@ class VacuumActionWrapper(DeviceWrapper[TuyaVacuumAction]):
             ),
         )
 
-    def get_update_commands(
+    def get_update_commands(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
         self, device: CustomerDevice, value: TuyaVacuumAction
     ) -> list[dict[str, Any]]:
         """Get the commands for the action wrapper."""

--- a/src/tuya_device_handlers/devices/__init__.py
+++ b/src/tuya_device_handlers/devices/__init__.py
@@ -20,7 +20,6 @@ def register_tuya_quirks(custom_quirks_path: str | None = None) -> None:
     - add quirks from `devices` subfolder
     - add custom quirks from `custom_quirks_path`
     """
-
     if custom_quirks_path is not None:
         TUYA_QUIRKS_REGISTRY.purge_custom_quirks(custom_quirks_path)
 
@@ -40,7 +39,8 @@ def register_tuya_quirks(custom_quirks_path: str | None = None) -> None:
 
     loaded = False
 
-    # Treat the custom quirk path (e.g. `/config/tuya_quirks/`) itself as a module
+    # Treat the custom quirk path (e.g. `/config/tuya_quirks/`)
+    # itself as a module
     for importer, modname, _ispkg in pkgutil.walk_packages(path=[str(path)]):
         _LOGGER.debug("Loading custom quirk module %r", modname)
 
@@ -53,7 +53,7 @@ def register_tuya_quirks(custom_quirks_path: str | None = None) -> None:
             module = importlib.util.module_from_spec(spec)
             sys.modules[modname] = module
             spec.loader.exec_module(module)
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             _LOGGER.exception(
                 "Unexpected exception importing custom quirk %r", modname
             )

--- a/src/tuya_device_handlers/helpers/homeassistant.py
+++ b/src/tuya_device_handlers/helpers/homeassistant.py
@@ -262,7 +262,7 @@ class TuyaNumberDeviceClass(StrEnum):
     CO = "carbon_monoxide"
     """Carbon Monoxide gas concentration.
 
-    Unit of measurement: `ppb` (parts per billion), `ppm` (parts per million), `mg/m³`, `μg/m³`
+    Unit of measurement: `ppb`, `ppm`, `mg/m³`, `μg/m³`
     """
 
     CO2 = "carbon_dioxide"
@@ -312,25 +312,33 @@ class TuyaNumberDeviceClass(StrEnum):
     ENERGY = "energy"
     """Energy.
 
-    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`, `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`, `Mcal`, `Gcal`
+    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`,
+    `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`,
+    `Mcal`, `Gcal`
     """
 
     ENERGY_DISTANCE = "energy_distance"
     """Energy distance.
 
-    Use this device class for sensors measuring energy by distance, for example the amount
-    of electric energy consumed by an electric car.
+    Use this device class for sensors measuring energy
+    by distance, for example the amount of electric
+    energy consumed by an electric car.
 
-    Unit of measurement: `kWh/100km`, `Wh/km`, `mi/kWh`, `km/kWh`
+    Unit of measurement: `kWh/100km`, `Wh/km`,
+    `mi/kWh`, `km/kWh`
     """
 
     ENERGY_STORAGE = "energy_storage"
     """Stored energy.
 
-    Use this device class for sensors measuring stored energy, for example the amount
-    of electric energy currently stored in a battery or the capacity of a battery.
+    Use this device class for sensors measuring stored
+    energy, for example the amount of electric energy
+    currently stored in a battery or the capacity of
+    a battery.
 
-    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`, `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`, `Mcal`, `Gcal`
+    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`,
+    `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`,
+    `Mcal`, `Gcal`
     """
 
     FREQUENCY = "frequency"
@@ -384,13 +392,13 @@ class TuyaNumberDeviceClass(StrEnum):
     NITROGEN_DIOXIDE = "nitrogen_dioxide"
     """Amount of NO2.
 
-    Unit of measurement: `ppb` (parts per billion), `ppm` (parts per million), `μg/m³`
+    Unit of measurement: `ppb`, `ppm`, `μg/m³`
     """
 
     NITROGEN_MONOXIDE = "nitrogen_monoxide"
     """Amount of NO.
 
-    Unit of measurement: `ppb` (parts per billion), `μg/m³`
+    Unit of measurement: `ppb`, `μg/m³`
     """
 
     NITROUS_OXIDE = "nitrous_oxide"
@@ -402,7 +410,7 @@ class TuyaNumberDeviceClass(StrEnum):
     OZONE = "ozone"
     """Amount of O3.
 
-    Unit of measurement: `ppb` (parts per billion), `ppm` (parts per million), `μg/m³`
+    Unit of measurement: `ppb`, `ppm`, `μg/m³`
     """
 
     PH = "ph"
@@ -548,28 +556,31 @@ class TuyaNumberDeviceClass(StrEnum):
 
     Unit of measurement: `VOLUME_*` units
     - SI / metric: `mL`, `L`, `m³`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `fl. oz.`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`,
+      `fl. oz.`, `gal`
     """
 
     VOLUME_STORAGE = "volume_storage"
     """Generic stored volume.
 
-    Use this device class for sensors measuring stored volume, for example the amount
-    of fuel in a fuel tank.
+    Use this device class for sensors measuring stored
+    volume, for example the amount of fuel in a fuel
+    tank.
 
     Unit of measurement: `VOLUME_*` units
     - SI / metric: `mL`, `L`, `m³`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `fl. oz.`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`,
+      `fl. oz.`, `gal`
     """
 
     VOLUME_FLOW_RATE = "volume_flow_rate"
     """Generic flow rate
 
     Unit of measurement: UnitOfVolumeFlowRate
-    - SI / metric: `m³/h`, `m³/min`, `m³/s`, `L/h`, `L/min`, `L/s`, `mL/s`
-    - USCS / imperial: `ft³/min`, `gal/min`, `gal/d`
+    - SI / metric: `m³/h`, `m³/min`, `m³/s`,
+      `L/h`, `L/min`, `L/s`, `mL/s`
+    - USCS / imperial: `ft³/min`, `gal/min`,
+      `gal/d`
     """
 
     WATER = "water"
@@ -577,14 +588,15 @@ class TuyaNumberDeviceClass(StrEnum):
 
     Unit of measurement:
     - SI / metric: `m³`, `L`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`, `gal`
     """
 
     WEIGHT = "weight"
-    """Generic weight, represents a measurement of an object's mass.
+    """Generic weight, represents a measurement of
+    an object's mass.
 
-    Weight is used instead of mass to fit with every day language.
+    Weight is used instead of mass to fit with
+    every day language.
 
     Unit of measurement: `MASS_*` units
     - SI / metric: `μg`, `mg`, `g`, `kg`
@@ -731,27 +743,36 @@ class TuyaSensorDeviceClass(StrEnum):
     ENERGY = "energy"
     """Energy.
 
-    Use this device class for sensors measuring energy consumption, for example
-    electric energy consumption.
-    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`, `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`, `Mcal`, `Gcal`
+    Use this device class for sensors measuring energy
+    consumption, for example electric energy consumption.
+
+    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`,
+    `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`,
+    `Mcal`, `Gcal`
     """
 
     ENERGY_DISTANCE = "energy_distance"
     """Energy distance.
 
-    Use this device class for sensors measuring energy by distance, for example the amount
-    of electric energy consumed by an electric car.
+    Use this device class for sensors measuring energy
+    by distance, for example the amount of electric
+    energy consumed by an electric car.
 
-    Unit of measurement: `kWh/100km`, `Wh/km`, `mi/kWh`, `km/kWh`
+    Unit of measurement: `kWh/100km`, `Wh/km`,
+    `mi/kWh`, `km/kWh`
     """
 
     ENERGY_STORAGE = "energy_storage"
     """Stored energy.
 
-    Use this device class for sensors measuring stored energy, for example the amount
-    of electric energy currently stored in a battery or the capacity of a battery.
+    Use this device class for sensors measuring stored
+    energy, for example the amount of electric energy
+    currently stored in a battery or the capacity of
+    a battery.
 
-    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`, `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`, `Mcal`, `Gcal`
+    Unit of measurement: `J`, `kJ`, `MJ`, `GJ`, `mWh`,
+    `Wh`, `kWh`, `MWh`, `GWh`, `TWh`, `cal`, `kcal`,
+    `Mcal`, `Gcal`
     """
 
     FREQUENCY = "frequency"
@@ -964,27 +985,29 @@ class TuyaSensorDeviceClass(StrEnum):
 
     Unit of measurement: `VOLUME_*` units
     - SI / metric: `mL`, `L`, `m³`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `fl. oz.`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`,
+      `fl. oz.`, `gal`
     """
 
     VOLUME_STORAGE = "volume_storage"
     """Generic stored volume.
 
-    Use this device class for sensors measuring stored volume, for example the amount
-    of fuel in a fuel tank.
+    Use this device class for sensors measuring stored
+    volume, for example the amount of fuel in a fuel
+    tank.
 
     Unit of measurement: `VOLUME_*` units
     - SI / metric: `mL`, `L`, `m³`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `fl. oz.`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`,
+      `fl. oz.`, `gal`
     """
 
     VOLUME_FLOW_RATE = "volume_flow_rate"
     """Generic flow rate
 
     Unit of measurement: UnitOfVolumeFlowRate
-    - SI / metric: `m³/h`, `m³/min`, `m³/s`, `L/h`, `L/min`, `L/s`, `mL/s`
+    - SI / metric: `m³/h`, `m³/min`, `m³/s`,
+      `L/h`, `L/min`, `L/s`, `mL/s`
     - USCS / imperial: `ft³/min`, `gal/min`
     """
 
@@ -993,14 +1016,15 @@ class TuyaSensorDeviceClass(StrEnum):
 
     Unit of measurement:
     - SI / metric: `m³`, `L`
-    - USCS / imperial: `ft³`, `CCF`, `MCF`, `gal` (warning: volumes expressed in
-    USCS/imperial units are currently assumed to be US volumes)
+    - USCS / imperial: `ft³`, `CCF`, `MCF`, `gal`
     """
 
     WEIGHT = "weight"
-    """Generic weight, represents a measurement of an object's mass.
+    """Generic weight, represents a measurement of
+    an object's mass.
 
-    Weight is used instead of mass to fit with every day language.
+    Weight is used instead of mass to fit with
+    every day language.
 
     Unit of measurement: `MASS_*` units
     - SI / metric: `μg`, `mg`, `g`, `kg`
@@ -1028,10 +1052,10 @@ class TuyaSensorStateClass(StrEnum):
     """State class for sensors."""
 
     MEASUREMENT = "measurement"
-    """The state represents a measurement in present time."""
+    """The state represents a measurement."""
 
     MEASUREMENT_ANGLE = "measurement_angle"
-    """The state represents a angle measurement in present time. Currently only degrees are supported."""
+    """Angle measurement. Only degrees supported."""
 
     TOTAL = "total"
     """The state represents a total amount.

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -6,10 +6,8 @@ from typing import Any, Protocol, Self
 
 from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
-    FeederSchedule,
-)
+from .device_wrapper.base import DeviceWrapper
+from .device_wrapper.service_feeder_schedule import FeederSchedule
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,15 +24,20 @@ class DeviceQuirkProtocol(Protocol):
     model_id: str | None
 
     @property
-    def quirk_file(self) -> pathlib.Path: ...
-    @property
-    def quirk_file_line(self) -> int: ...
+    def quirk_file(self) -> pathlib.Path:
+        """Get the quirk file path."""
 
-    def initialise_device(self, device: CustomerDevice) -> None: ...
+    @property
+    def quirk_file_line(self) -> int:
+        """Get the quirk file line number."""
+
+    def initialise_device(self, device: CustomerDevice) -> None:
+        """Initialize the device with this quirk."""
 
     def get_feeder_schedules_wrapper(
         self, device: CustomerDevice
-    ) -> DeviceWrapper[list[FeederSchedule]] | None: ...
+    ) -> DeviceWrapper[list[FeederSchedule]] | None:
+        """Get the feeder schedules wrapper for a device."""
 
 
 class QuirksRegistry:

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -21,9 +21,10 @@ _LOG_OR_QUIRK = (
 
 
 def _should_log_warning(device_id: str, warning_key: str) -> bool:
-    """Check if a warning has already been logged for a device and add it if not.
+    """Check if a warning was already logged for a device.
 
-    Returns: True if the warning should be logged, False if it was already logged.
+    Returns: True if the warning should be logged,
+    False if it was already logged.
     """
     if (device_warnings := DEVICE_WARNINGS.get(device_id)) is None:
         device_warnings = set()
@@ -47,7 +48,11 @@ class TypeInformation[T](abc.ABC):
 
     @classmethod
     def _from_json(
-        cls, dpcode: str, type_data: str, *, report_type: str | None
+        cls,
+        dpcode: str,
+        type_data: str,
+        *,
+        report_type: str | None,  # noqa: ARG003
     ) -> Self | None:
         """Load JSON string and return a TypeInformation object."""
         return cls(dpcode=dpcode, type_data=type_data)
@@ -60,7 +65,7 @@ class TypeInformation[T](abc.ABC):
         *,
         prefer_function: bool = False,
     ) -> Self | None:
-        """Find type information for a matching DP code available for this device."""
+        """Find type information for a matching DP code."""
         if dpcodes is None:
             return None
 
@@ -110,7 +115,11 @@ class BitmapTypeInformation(TypeInformation[int]):
 
     @classmethod
     def _from_json(
-        cls, dpcode: str, type_data: str, *, report_type: str | None
+        cls,
+        dpcode: str,
+        type_data: str,
+        *,
+        report_type: str | None,  # noqa: ARG003
     ) -> Self | None:
         """Load JSON string and return a BitmapTypeInformation object."""
         if not (parsed := cast(dict[str, Any] | None, json.loads(type_data))):
@@ -122,6 +131,7 @@ class BitmapTypeInformation(TypeInformation[int]):
         )
 
     def read_device_value(self, device: CustomerDevice) -> int | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         if isinstance(raw_value, int):
@@ -148,6 +158,7 @@ class BooleanTypeInformation(TypeInformation[bool]):
     _DPTYPE = DPType.BOOLEAN
 
     def read_device_value(self, device: CustomerDevice) -> bool | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         if raw_value in (True, False):
@@ -178,7 +189,11 @@ class EnumTypeInformation(TypeInformation[str]):
 
     @classmethod
     def _from_json(
-        cls, dpcode: str, type_data: str, *, report_type: str | None
+        cls,
+        dpcode: str,
+        type_data: str,
+        *,
+        report_type: str | None,  # noqa: ARG003
     ) -> Self | None:
         """Load JSON string and return an EnumTypeInformation object."""
         if not (parsed := json.loads(type_data)):
@@ -190,6 +205,7 @@ class EnumTypeInformation(TypeInformation[str]):
         )
 
     def read_device_value(self, device: CustomerDevice) -> str | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         # Validate input against defined range
@@ -253,6 +269,7 @@ class IntegerTypeInformation(TypeInformation[float]):
         )
 
     def read_device_value(self, device: CustomerDevice) -> float | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         # Validate input against defined range
@@ -285,6 +302,7 @@ class JsonTypeInformation(TypeInformation[dict[str, Any]]):
     def read_device_value(
         self, device: CustomerDevice
     ) -> dict[str, Any] | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         try:
@@ -310,6 +328,7 @@ class RawTypeInformation(TypeInformation[bytes]):
     _DPTYPE = DPType.RAW
 
     def read_device_value(self, device: CustomerDevice) -> bytes | None:
+        """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
             return None
         try:
@@ -335,4 +354,5 @@ class StringTypeInformation(TypeInformation[str]):
     _DPTYPE = DPType.STRING
 
     def read_device_value(self, device: CustomerDevice) -> str | None:
+        """Read the device value for this datapoint."""
         return cast(str, device.status.get(self.dpcode))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
 
 def _date_as_timestamp(date_string: str | None) -> int:
-    # "2023-06-21T04:29:09+00:00"
+    # Expected format: "2023-06-21T04:29:09+00:00"
     if date_string is None:
         return 0
     return int(datetime.fromisoformat(date_string).timestamp())
@@ -108,13 +108,15 @@ def send_device_update(
     device: CustomerDevice,
     updated_status_properties: dict[str, Any] | None = None,
 ) -> None:
-    """Send device update"""
+    """Send device update."""
     property_list: list[str] = []
     if updated_status_properties:
         for key, value in updated_status_properties.items():
             if key not in device.status:
-                raise ValueError(
-                    f"Property {key} not found in device status: {device.status}"
+                msg = (
+                    f"Property {key} not found in "
+                    f"device status: {device.status}"
                 )
+                raise ValueError(msg)
             device.status[key] = value
             property_list.append(key)

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -130,7 +130,7 @@ def test_remove_dpid() -> None:
 def test_initialise_device_read_and_write_with_local(
     mock_device: CustomerDevice,
 ) -> None:
-    """READ adds status_range; WRITE adds function; support_local adds strategy."""
+    """READ adds status_range; WRITE adds function."""
     mock_device.support_local = True
     mock_device.local_strategy = {}
     quirk = DeviceQuirk().add_dpid_integer(
@@ -187,7 +187,7 @@ def test_initialise_device_write_only_clears_status_range(
 def test_initialise_device_none_definition_removes_everything(
     mock_device: CustomerDevice,
 ) -> None:
-    """remove_dpid: function, local_strategy, status, status_range all popped."""
+    """remove_dpid: function, strategy, status all popped."""
     mock_device.support_local = True
     mock_device.local_strategy = {7: {"some": "thing"}}
     mock_device.function["g"] = DeviceFunction(
@@ -226,7 +226,7 @@ def test_applies_to_called_twice_raises() -> None:
 
 
 def test_register_without_applies_to_raises() -> None:
-    """register raises ValueError when applies_to was never called."""
+    """Register raises ValueError when applies_to was never called."""
     quirk = DeviceQuirk()
     with pytest.raises(
         ValueError, match="does not have an applies_to condition"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Test fixtures"""
+"""Test fixtures."""
 
 from collections.abc import Generator
 from unittest.mock import Mock, patch

--- a/tests/definition/__init__.py
+++ b/tests/definition/__init__.py
@@ -1,1 +1,1 @@
-"""Test entity definitions"""
+"""Test entity definitions."""

--- a/tests/definition/test_alarm_control_panel.py
+++ b/tests/definition/test_alarm_control_panel.py
@@ -12,7 +12,7 @@ from tuya_device_handlers.device_wrapper.alarm_control_panel import (
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("mal_gyitctrjj1kefxp2.json")
     assert (definition := get_default_definition(device))
     assert isinstance(definition.action_wrapper, AlarmActionWrapper)
@@ -21,6 +21,6 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sfkzq_ed7frwissyqrejic.json")
     assert not get_default_definition(device)

--- a/tests/definition/test_binary_sensor.py
+++ b/tests/definition/test_binary_sensor.py
@@ -22,7 +22,7 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 def test_get_default_definition(
     dpcode: str,
     bitmap_code: str | None,
-    on_values: bool | float | str | set[bool | float | int | str],
+    on_values: bool | float | int | str | set[bool | float | int | str],
     wrapper_type: type,
 ) -> None:
     """Test get_default_definition."""

--- a/tests/definition/test_binary_sensor.py
+++ b/tests/definition/test_binary_sensor.py
@@ -22,10 +22,10 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 def test_get_default_definition(
     dpcode: str,
     bitmap_code: str | None,
-    on_values: bool | float | int | str | set[bool | float | int | str],
+    on_values: bool | float | str | set[bool | float | int | str],
     wrapper_type: type,
 ) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert (
         definition := get_default_definition(
@@ -43,6 +43,6 @@ def test_get_default_definition(
     ],
 )
 def test_get_default_definition_fails(bitmap_code: str | None) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert not get_default_definition(device, "bad", bitmap_code, True)

--- a/tests/definition/test_button.py
+++ b/tests/definition/test_button.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sd_lr33znaodtyarrrz.json")
     assert (definition := get_default_definition(device, "reset_duster_cloth"))
     assert isinstance(definition.button_wrapper, DPCodeBooleanWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sd_lr33znaodtyarrrz.json")
     assert not get_default_definition(device, "bad")

--- a/tests/definition/test_camera.py
+++ b/tests/definition/test_camera.py
@@ -6,7 +6,7 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sp_rudejjigkywujjvs.json")
     assert (definition := get_default_definition(device))
     assert isinstance(definition.motion_detection_switch, DPCodeBooleanWrapper)

--- a/tests/definition/test_climate.py
+++ b/tests/definition/test_climate.py
@@ -16,7 +16,7 @@ from tuya_device_handlers.helpers.homeassistant import TuyaUnitOfTemperature
     "unit", [TuyaUnitOfTemperature.CELSIUS, TuyaUnitOfTemperature.FAHRENHEIT]
 )
 def test_get_default_definition(unit: TuyaUnitOfTemperature) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("kt_5wnlzekkstwcdsvm.json")
     assert (definition := get_default_definition(device, unit))
     assert not definition.current_humidity_wrapper
@@ -38,7 +38,7 @@ def test_get_default_definition(unit: TuyaUnitOfTemperature) -> None:
 def test_get_default_definition_with_convert(
     unit: TuyaUnitOfTemperature,
 ) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("wk_B0eP8qYAdpUo4yR9.json")
     assert (definition := get_default_definition(device, unit))
     assert not definition.current_humidity_wrapper

--- a/tests/definition/test_cover.py
+++ b/tests/definition/test_cover.py
@@ -12,7 +12,7 @@ from tuya_device_handlers.device_wrapper.extended import (
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cl_zah67ekd.json")
     assert (
         definition := get_default_definition(
@@ -40,7 +40,7 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cl_zah67ekd.json")
     assert not get_default_definition(
         device,

--- a/tests/definition/test_event.py
+++ b/tests/definition/test_event.py
@@ -9,7 +9,7 @@ from tuya_device_handlers.device_wrapper.event import (
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sp_sdd5f5f2dl5wydjf.json")
     assert (
         definition := get_default_definition(
@@ -20,6 +20,6 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sp_sdd5f5f2dl5wydjf.json")
     assert not get_default_definition(device, "bad", SimpleEventEnumWrapper)

--- a/tests/definition/test_fan.py
+++ b/tests/definition/test_fan.py
@@ -6,7 +6,7 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert (definition := get_default_definition(device))
     assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)
@@ -17,6 +17,6 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sfkzq_ed7frwissyqrejic.json")
     assert not get_default_definition(device)

--- a/tests/definition/test_humidifier.py
+++ b/tests/definition/test_humidifier.py
@@ -9,7 +9,7 @@ from tuya_device_handlers.device_wrapper.extended import (
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert (
         definition := get_default_definition(
@@ -27,7 +27,7 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert not get_default_definition(
         device,

--- a/tests/definition/test_init.py
+++ b/tests/definition/test_init.py
@@ -2,7 +2,7 @@
 
 
 def test_import() -> None:
-    """Test import of definitions"""
+    """Test import of definitions."""
     # ruff: disable[F401, PLC0415]
     from tuya_device_handlers.definition.alarm_control_panel import (
         AlarmControlPanelDefinition,

--- a/tests/definition/test_light.py
+++ b/tests/definition/test_light.py
@@ -16,7 +16,7 @@ from tuya_device_handlers.device_wrapper.light import (
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("dj_mki13ie507rlry4r.json")
     assert (
         definition := get_default_definition(
@@ -39,7 +39,7 @@ def test_get_default_definition() -> None:
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert not get_default_definition(
         device,

--- a/tests/definition/test_number.py
+++ b/tests/definition/test_number.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeIntegerWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("mal_gyitctrjj1kefxp2.json")
     assert (definition := get_default_definition(device, "delay_set"))
     assert isinstance(definition.number_wrapper, DPCodeIntegerWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("mal_gyitctrjj1kefxp2.json")
     assert not get_default_definition(device, "bad")

--- a/tests/definition/test_select.py
+++ b/tests/definition/test_select.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeEnumWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cl_zah67ekd.json")
     assert (definition := get_default_definition(device, "control_back_mode"))
     assert isinstance(definition.select_wrapper, DPCodeEnumWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cl_zah67ekd.json")
     assert not get_default_definition(device, "bad")

--- a/tests/definition/test_sensor.py
+++ b/tests/definition/test_sensor.py
@@ -42,7 +42,7 @@ def test_get_default_definition(
     lookup_type: tuple[type, ...] | None,
     wrapper_type: type,
 ) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device(fixture_filename)
     assert (definition := get_default_definition(device, dpcode, lookup_type))  # ty: ignore[invalid-argument-type]
     assert isinstance(definition.sensor_wrapper, wrapper_type)
@@ -58,6 +58,6 @@ def test_get_default_definition(
 def test_get_default_definition_fails(
     lookup_type: tuple[type, ...] | None,
 ) -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert not get_default_definition(device, "bad", lookup_type)  # ty: ignore[invalid-argument-type]

--- a/tests/definition/test_siren.py
+++ b/tests/definition/test_siren.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sp_sdd5f5f2dl5wydjf.json")
     assert (definition := get_default_definition(device, "siren_switch"))
     assert isinstance(definition.siren_wrapper, DPCodeBooleanWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sp_sdd5f5f2dl5wydjf.json")
     assert not get_default_definition(device, "bad")

--- a/tests/definition/test_switch.py
+++ b/tests/definition/test_switch.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cz_PGEkBctAbtzKOZng.json")
     assert (definition := get_default_definition(device, "switch"))
     assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("cz_PGEkBctAbtzKOZng.json")
     assert not get_default_definition(device, "bad")

--- a/tests/definition/test_vacuum.py
+++ b/tests/definition/test_vacuum.py
@@ -6,7 +6,7 @@ from tuya_device_handlers.device_wrapper.vacuum import VacuumActionWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sd_i6hyjg3af7doaswm.json")
     assert (definition := get_default_definition(device))
     assert isinstance(definition.action_wrapper, VacuumActionWrapper)

--- a/tests/definition/test_valve.py
+++ b/tests/definition/test_valve.py
@@ -6,13 +6,13 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 
 
 def test_get_default_definition() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sfkzq_ed7frwissyqrejic.json")
     assert (definition := get_default_definition(device, "switch_1"))
     assert isinstance(definition.control_wrapper, DPCodeBooleanWrapper)
 
 
 def test_get_default_definition_fails() -> None:
-    """Test get_default_definition"""
+    """Test get_default_definition."""
     device = create_device("sfkzq_ed7frwissyqrejic.json")
     assert not get_default_definition(device, "bad")

--- a/tests/device_wrapper/__init__.py
+++ b/tests/device_wrapper/__init__.py
@@ -1,12 +1,11 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 
 from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
+from tests import send_device_update
 from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-
-from .. import send_device_update
 
 
 def send_wrapper_update(
@@ -15,7 +14,7 @@ def send_wrapper_update(
     updated_status_properties: dict[str, Any] | None = None,
     dp_timestamps: dict[str, int] | None = None,
 ) -> None:
-    """Send device update, and trigger skip_update"""
+    """Send device update, and trigger skip_update."""
     send_device_update(device, updated_status_properties)
     if updated_status_properties:
         wrapper.skip_update(
@@ -26,12 +25,14 @@ def send_wrapper_update(
 def inject_dpcode_status(
     mock_device: CustomerDevice, dpcode: str, state: Any
 ) -> None:
+    """Inject a status value for a dpcode into a mock device."""
     mock_device.status[dpcode] = state
 
 
 def inject_dpcode_function(
     mock_device: CustomerDevice, dpcode: str, dptype: str, values: str
 ) -> None:
+    """Inject a function definition for a dpcode into a mock device."""
     mock_device.function[dpcode] = DeviceFunction(
         {"code": dpcode, "type": dptype, "values": values}
     )
@@ -40,6 +41,7 @@ def inject_dpcode_function(
 def inject_dpcode_status_range(
     mock_device: CustomerDevice, dpcode: str, dptype: str, values: str
 ) -> None:
+    """Inject a status range definition for a dpcode into a mock device."""
     mock_device.status_range[dpcode] = DeviceStatusRange(
         {"code": dpcode, "type": dptype, "values": values}
     )
@@ -55,6 +57,7 @@ def inject_dpcode(
     skip_function: bool = False,
     skip_status_range: bool = False,
 ) -> None:
+    """Inject a dpcode with status, function, and status range."""
     inject_dpcode_status(mock_device, dpcode, state)
     if dptype is not None:
         if not skip_function:

--- a/tests/device_wrapper/test_alarm_control_panel.py
+++ b/tests/device_wrapper/test_alarm_control_panel.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 
@@ -74,7 +74,7 @@ def _inject_default_alarm_codes(mock_device: CustomerDevice) -> None:
                 "master_mode": "home",
                 "master_state": "alarm",
                 # "Sensor Low Battery Test Sensor" in UTF-16BE
-                "alarm_msg": "AFMAZQBuAHMAbwByACAATABvAHcAIABCAGEAdAB0AGUAcgB5ACAAVABlAHMAdAAgAFMAZQBuAHMAbwBy",
+                "alarm_msg": "AFMAZQBuAHMAbwByACAATABvAHcAIABCAGEAdAB0AGUAcgB5ACAAVABlAHMAdAAgAFMAZQBuAHMAbwBy",  # noqa: E501
             },
             TuyaAlarmControlPanelState.ARMED_HOME,
             "Sensor Low Battery Test Sensor",

--- a/tests/device_wrapper/test_base.py
+++ b/tests/device_wrapper/test_base.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from tuya_sharing import CustomerDevice
 

--- a/tests/device_wrapper/test_binary_sensor.py
+++ b/tests/device_wrapper/test_binary_sensor.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_climate.py
+++ b/tests/device_wrapper/test_climate.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 
@@ -60,6 +60,7 @@ def test_read_swing_mode(
     expected_device_status: Any,
     mock_device: CustomerDevice,
 ) -> None:
+    """Test reading swing mode from device status."""
     if sample == "swing_only":
         inject_dpcode(mock_device, "swing", None, dptype="Boolean")
     if sample in {"horizontal_only", "both"}:
@@ -76,6 +77,7 @@ def test_read_swing_mode(
 def test_swing_mode_unavailable(
     mock_device: CustomerDevice,
 ) -> None:
+    """Test swing mode returns None when no dpcode is available."""
     wrapper = SwingModeCompositeWrapper.find_dpcode(mock_device)
 
     assert wrapper is None
@@ -185,6 +187,7 @@ def test_read_hvac_preset(
     expected_preset: Any,
     mock_device: CustomerDevice,
 ) -> None:
+    """Test reading HVAC mode and preset from device status."""
     inject_dpcode(
         mock_device,
         "mode",

--- a/tests/device_wrapper/test_common.py
+++ b/tests/device_wrapper/test_common.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 import base64
 from typing import Any

--- a/tests/device_wrapper/test_cover.py
+++ b/tests/device_wrapper/test_cover.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_event.py
+++ b/tests/device_wrapper/test_event.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_extended.py
+++ b/tests/device_wrapper/test_extended.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_fan.py
+++ b/tests/device_wrapper/test_fan.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_sensor.py
+++ b/tests/device_wrapper/test_sensor.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 

--- a/tests/device_wrapper/test_service_feeder_schedule.py
+++ b/tests/device_wrapper/test_service_feeder_schedule.py
@@ -1,9 +1,10 @@
-"""Test DeviceWrapper feeder schedule functionality"""
+"""Test DeviceWrapper feeder schedule functionality."""
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
+from tests import create_device
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.builder.device_quirk import DeviceQuirk
 from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
@@ -11,8 +12,6 @@ from tuya_device_handlers.device_wrapper.service_feeder_schedule import (
     FeederSchedule,
     get_feeder_schedule_wrapper,
 )
-
-from .. import create_device
 
 _SAMPLE_MEAL_PLAN = [
     FeederSchedule(

--- a/tests/device_wrapper/test_vacuum.py
+++ b/tests/device_wrapper/test_vacuum.py
@@ -1,4 +1,4 @@
-"""Test DeviceWrapper classes"""
+"""Test DeviceWrapper classes."""
 
 from typing import Any
 
@@ -61,7 +61,7 @@ def test_read_device_status(
             "status",
             "charge_done",
             dptype="Enum",
-            values='{"range": ["standby","zone_clean","part_clean","cleaning","paused","goto_pos","pos_arrived","pos_unarrive","goto_charge","charging","charge_done","sleep"]}',
+            values='{"range": ["standby","zone_clean","part_clean","cleaning","paused","goto_pos","pos_arrived","pos_unarrive","goto_charge","charging","charge_done","sleep"]}',  # noqa: E501
         )
 
     mock_device.status.update(status_updates)

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,1 +1,1 @@
-"""Test helpers"""
+"""Test helpers."""

--- a/tests/helpers/test_diagnostics.py
+++ b/tests/helpers/test_diagnostics.py
@@ -1,13 +1,12 @@
-"""Test diagnostics helpers"""
+"""Test diagnostics helpers."""
 
 from syrupy.assertion import SnapshotAssertion
 
+from tests import create_device
 from tuya_device_handlers.helpers.diagnostics import customer_device_as_dict
-
-from .. import create_device
 
 
 def test_customer_device_as_dict(snapshot: SnapshotAssertion) -> None:
-    """Test customer_device_as_dict"""
+    """Test customer_device_as_dict."""
     device = create_device("sfkzq_ed7frwissyqrejic.json")
     assert customer_device_as_dict(device) == snapshot

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,4 +1,4 @@
-"""Test constants"""
+"""Test constants."""
 
 import pytest
 

--- a/tests/test_raw_data_model.py
+++ b/tests/test_raw_data_model.py
@@ -1,4 +1,4 @@
-"""Test utils"""
+"""Test utils."""
 
 import base64
 import dataclasses

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,7 +9,7 @@ from tuya_device_handlers.registry import QuirksRegistry
 
 
 def test_singleton_preserves_state() -> None:
-    """Test that re-instantiating QuirksRegistry does not wipe registered quirks."""
+    """Re-instantiating QuirksRegistry preserves quirks."""
     reg = QuirksRegistry()
 
     # Register a quirk
@@ -50,7 +50,7 @@ def test_initialise_device_quirk_no_match_is_noop() -> None:
 
 
 def test_purge_custom_quirks_removes_quirks_under_root() -> None:
-    """purge_custom_quirks drops quirks whose file lives under the given root."""
+    """purge_custom_quirks drops quirks under the given root."""
     reg = QuirksRegistry()
 
     custom_root = "/tmp/custom_quirks"

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -1,4 +1,4 @@
-"""Test TypeInformation classes"""
+"""Test TypeInformation classes."""
 
 import dataclasses
 from typing import Any
@@ -145,7 +145,6 @@ def test_integer_scaling(mock_device: CustomerDevice) -> None:
             "Found invalid RAW value `some_string` (<class 'str'>) "
             "for datapoint `demo_raw` in product id `product_id`",
         ),
-        # (StringTypeInformation, "demo_string", "some_string", "", ""),
     ],
 )
 @patch.dict(DEVICE_WARNINGS, {}, clear=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-"""Test utils"""
+"""Test utils."""
 
 from tuya_sharing import CustomerDevice
 


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

Expand ruff linting from a selective rule set (12 categories) to `select = ALL`, enabling comprehensive code quality checks. Additionally, removed a few pylint rules that have been disabled previously.

**Ruff config:**

- Change `select` from explicit category list to `["ALL"]`
- Update `ignore` list: core ignores match the fumis reference standard (ANN401, D203, D213, D417, PLR2004, COM812, ISC001), plus a small set of pre-existing patterns tracked for future cleanup
- Add `per-file-ignores` for test-specific patterns (S101 assert, SLF001 private access, A002 builtin shadowing, etc.)
- Add inline `noqa` where fixing would hurt readability (SIM102 on two complex nested ifs, PLR0911 on vacuum command dispatch, A002 on builder min/max params, ARG003 on interface-conforming parameters)

**Pylint config:**

- Re-enable 9 previously disabled pylint rules by moving suppression to inline comments on the specific lines that need them (arguments-differ, invalid-name, broad-exception-caught, import-outside-toplevel, redefined-builtin, too-many-positional-arguments, too-many-return-statements, missing-class-docstring, missing-function-docstring)
- Remove unnecessary ellipsis from Protocol stubs (docstrings now serve as the method body)

**Code fixes:**

- Add missing docstrings to all public classes, methods, and functions (D101, D102, D103, D107)
- Add terminal punctuation to all test docstrings (D415)
- Extract exception message strings to variables (EM101, EM102)
- Convert manual list append loop to list comprehension (PERF401)
- Remove commented-out test case (ERA001)
- Reword a date format comment to not trigger ERA001
- Wrap long lines to fit 80 chars (E501)
- Convert relative parent imports to absolute imports (TID252)
- Apply ruff auto-fixes: redundant numeric union (PYI041), blank line after docstring (D202)

## Test plan

<!-- How was it tested? -->

poetry run prek run --all-files

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

N/A