### PR TITLE
Add ability to override device category

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -71,6 +71,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     def __init__(self) -> None:
         """Initialize the quirk."""
         self._applies_to: str | None = None
+        self._override_category: str | None = None
 
         self._datapoint_definitions = {}
         self._get_wrapper_functions = {}
@@ -96,6 +97,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     def initialise_device(self, device: CustomerDevice) -> None:
         """Initialise device."""
+        if self._override_category is not None:
+            device.category = self._override_category
         self.original_function = device.function.copy()
         self.original_local_strategy = device.local_strategy.copy()
         self.original_status_range = device.status_range.copy()
@@ -147,6 +150,11 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self.manufacturer = manufacturer
         self.model = model
         self.model_id = model_id
+        return self
+
+    def override_category(self, category: str) -> Self:
+        """Set category override applied during initialise_device."""
+        self._override_category = category
         return self
 
     def register(self, registry: QuirksRegistry) -> None:

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -97,11 +97,12 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     def initialise_device(self, device: CustomerDevice) -> None:
         """Initialise device."""
-        if self._override_category is not None:
-            device.category = self._override_category
         self.original_function = device.function.copy()
         self.original_local_strategy = device.local_strategy.copy()
         self.original_status_range = device.status_range.copy()
+
+        if self._override_category is not None:
+            device.category = self._override_category
 
         for key, definition in self._datapoint_definitions.items():
             dpid, dpcode = key

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -127,6 +127,12 @@ def test_remove_dpid() -> None:
     assert quirk._datapoint_definitions[(5, "rm")] is None
 
 
+def test_override_category() -> None:
+    """override_category stores the new category on the quirk."""
+    quirk = DeviceQuirk().override_category("kg")
+    assert quirk._override_category == "kg"
+
+
 def test_initialise_device_read_and_write_with_local(
     mock_device: CustomerDevice,
 ) -> None:
@@ -203,6 +209,30 @@ def test_initialise_device_none_definition_removes_everything(
     assert 7 not in mock_device.local_strategy
     assert "g" not in mock_device.status
     assert "g" not in mock_device.status_range
+
+
+def test_initialise_device_override_category(
+    mock_device: CustomerDevice,
+) -> None:
+    """initialise_device remaps device.category when an override is set."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    mock_device.category = "original"
+    quirk = DeviceQuirk().override_category("kg")
+    quirk.initialise_device(mock_device)
+    assert mock_device.category == "kg"
+
+
+def test_initialise_device_without_override_category(
+    mock_device: CustomerDevice,
+) -> None:
+    """initialise_device leaves device.category alone without an override."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    mock_device.category = "original"
+    quirk = DeviceQuirk()
+    quirk.initialise_device(mock_device)
+    assert mock_device.category == "original"
 
 
 def test_applies_to_records_manufacturer_and_model() -> None:


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

Sometimes the device category exposed by the API is wrong.
This allows users to override it.

## Test plan

`pytest tests`

## Related issue

Extracted from and needed for #154
