### PR TITLE
Add DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "containerEnv": {
+    "POETRY_VIRTUALENVS_IN_PROJECT": "true"
+  },
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["README.md"]
+    },
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode",
+        "GitHub.vscode-pull-request-github",
+        "charliermarsh.ruff",
+        "GitHub.vscode-github-actions",
+        "ryanluker.vscode-coverage-gutters"
+      ],
+      "settings": {
+        "[python]": {
+          "editor.codeActionsOnSave": {
+            "source.fixAll": true,
+            "source.organizeImports": true
+          }
+        },
+        "coverage-gutters.customizable.context-menu": true,
+        "coverage-gutters.customizable.status-bar-toggler-watchCoverageAndVisibleEditors-enabled": true,
+        "coverage-gutters.showGutterCoverage": false,
+        "coverage-gutters.showLineCoverage": true,
+        "coverage-gutters.xmlname": "coverage.xml",
+        "python.analysis.extraPaths": ["${workspaceFolder}/src"],
+        "python.defaultInterpreterPath": ".venv/bin/python",
+        "python.testing.cwd": "${workspaceFolder}",
+        "python.testing.pytestArgs": ["--cov-report=xml"],
+        "python.testing.pytestEnabled": true,
+        "ruff.importStrategy": "fromEnvironment",
+        "ruff.interpreter": [".venv/bin/python"],
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/poetry:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "installTools": false,
+      "version": "3.14"
+    }
+  },
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "name": "Tuya device quirks library",
+  "updateContentCommand": ". ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install && poetry run prek install"
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,15 +35,28 @@ Request features on the [Issue Tracker].
 
 ## How to set up your development environment
 
-You need Python 3.13+ and [Poetry].
+The easiest way to get started is to use the [Dev Container][devcontainer]:
 
-Install the package with development requirements:
+[![Open in Dev Containers][devcontainer-shield]][devcontainer]
+
+This gives you a fully configured environment with Python, Poetry,
+Node.js, and all development tools pre-installed.
+
+[devcontainer]: https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/home-assistant-libs/tuya-device-handlers
+[devcontainer-shield]: https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode
+
+### Manual setup
+
+You need Python 3.13+, [Poetry], and [Node.js] (for Prettier).
 
 ```console
+$ npm install
 $ poetry install
+$ poetry run prek install
 ```
 
 [poetry]: https://python-poetry.org/
+[node.js]: https://nodejs.org/
 
 ## How to test the project
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Tests](https://github.com/home-assistant-libs/tuya-device-handlers/workflows/Testing/badge.svg)][tests]
 [![Codecov](https://codecov.io/gh/home-assistant-libs/tuya-device-handlers/branch/main/graph/badge.svg)][codecov]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
+[![Open in Dev Containers][devcontainer-shield]][devcontainer]
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
@@ -17,6 +18,8 @@
 [codecov]: https://app.codecov.io/gh/home-assistant-libs/tuya-device-handlers
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/home-assistant-libs/tuya-device-handlers
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/home-assistant-libs/tuya-device-handlers/badge
+[devcontainer]: https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/home-assistant-libs/tuya-device-handlers
+[devcontainer-shield]: https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [ruff]: https://github.com/astral-sh/ruff
 


### PR DESCRIPTION
Add a DevContainer configuration for a consistent development environment in VS Code, Codespaces, and other DevContainer-compatible tools.

The container includes Python 3.14, Poetry, Node.js (for Prettier), and GitHub CLI. The `updateContentCommand` installs all dependencies and sets up pre-commit hooks automatically. VS Code is configured with Ruff, coverage gutters, and Python auto-fix on save.

## Changes

- Add `.devcontainer/devcontainer.json`
- Add Dev Container badge to README
- Update CONTRIBUTING.md with Dev Container as the recommended setup method and add manual setup section with Node.js