### PR TITLE
Add quirk for Quark inverter pool heat pump (5xe6dkfmdafvrasa)

### DIFF
--- a/src/tuya_device_handlers/devices/qn/__init__.py
+++ b/src/tuya_device_handlers/devices/qn/__init__.py
@@ -1,0 +1,4 @@
+"""Quirks for Tuya QN category (heater).
+
+https://developer.tuya.com/en/docs/iot/categoryqn?id=Kaiuz18kih0sm
+"""

--- a/src/tuya_device_handlers/devices/qn/qn_5xe6dkfmdafvrasa.py
+++ b/src/tuya_device_handlers/devices/qn/qn_5xe6dkfmdafvrasa.py
@@ -1,0 +1,262 @@
+"""Quirk for Quark inverter pool heat pump (product_id 5xe6dkfmdafvrasa).
+
+OEM-branded as Madimack Elite V4-120 in Australia among others. Tuya cloud
+returns empty ``function``/``status_range``/``local_strategy`` for this
+device, so Home Assistant cannot build a usable climate entity. The
+datapoint definitions below were retrieved from the Tuya Developer Portal
+Standard Instruction Set for product ``5xe6dkfmdafvrasa`` (夸克热泵20231219 /
+"Quark heat pump 20231219").
+
+DP 117 (``temp_inflow``) and DP 114 (``temp_effluent``) report water
+temperatures multiplied by 10 (i.e. 305 means 30.5 °C); all other temperature
+DPs are reported as whole °C.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="5xe6dkfmdafvrasa")
+    # Power on/off.
+    .add_dpid_boolean(
+        dpid=101,
+        dpcode="switch1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    # Operating mode.
+    .add_dpid_enum(
+        dpid=102,
+        dpcode="mode1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["heating", "cooling", "auto"],
+    )
+    # Child lock.
+    .add_dpid_boolean(
+        dpid=103,
+        dpcode="child_lock1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    # Target water temperature.
+    .add_dpid_integer(
+        dpid=104,
+        dpcode="temp_set1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="℃",
+        min=7,
+        max=35,
+        scale=0,
+        step=1,
+    )
+    # Work mode preset (turbo / silent / smart).
+    .add_dpid_enum(
+        dpid=105,
+        dpcode="work_mode",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["power", "silent", "smart"],
+    )
+    # Temperature unit (celsius / fahrenheit).
+    .add_dpid_enum(
+        dpid=106,
+        dpcode="temp_unit_convert1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["c", "f"],
+    )
+    # Fault code (primary).
+    .add_dpid_integer(
+        dpid=107,
+        dpcode="fault1",
+        dpmode=DPMode.READ,
+        unit="",
+        min=0,
+        max=255,
+        scale=0,
+        step=1,
+    )
+    # Current temperature (display-side, mirrors inflow).
+    .add_dpid_integer(
+        dpid=108,
+        dpcode="temp_current1",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Compressor speed / load.
+    .add_dpid_integer(
+        dpid=109,
+        dpcode="compressor_strength",
+        dpmode=DPMode.READ,
+        unit="%",
+        min=0,
+        max=100,
+        scale=0,
+        step=1,
+    )
+    # User-configurable upper temperature limit.
+    .add_dpid_integer(
+        dpid=110,
+        dpcode="temp_top",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="℃",
+        min=7,
+        max=45,
+        scale=0,
+        step=1,
+    )
+    # User-configurable lower temperature limit.
+    .add_dpid_integer(
+        dpid=111,
+        dpcode="temp_bottom",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="℃",
+        min=-30,
+        max=35,
+        scale=0,
+        step=1,
+    )
+    # Outer coil temperature.
+    .add_dpid_integer(
+        dpid=112,
+        dpcode="temp_coiler",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Compressor discharge temperature.
+    .add_dpid_integer(
+        dpid=113,
+        dpcode="temp_venting",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=150,
+        scale=0,
+        step=1,
+    )
+    # Effluent (outlet) water temperature, reported x10.
+    .add_dpid_integer(
+        dpid=114,
+        dpcode="temp_effluent",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-300,
+        max=990,
+        scale=1,
+        step=1,
+    )
+    # Ambient air temperature.
+    .add_dpid_integer(
+        dpid=115,
+        dpcode="temp_around",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-50,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Fault code (secondary).
+    .add_dpid_integer(
+        dpid=116,
+        dpcode="fault2",
+        dpmode=DPMode.READ,
+        unit="",
+        min=0,
+        max=255,
+        scale=0,
+        step=1,
+    )
+    # Inflow (inlet) water temperature, reported x10.
+    .add_dpid_integer(
+        dpid=117,
+        dpcode="temp_inflow",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-300,
+        max=990,
+        scale=1,
+        step=1,
+    )
+    # Refrigerant return-line temperature.
+    .add_dpid_integer(
+        dpid=118,
+        dpcode="temp_return",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Inner coil temperature.
+    .add_dpid_integer(
+        dpid=119,
+        dpcode="temp_coiler_inside",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Radiator/heat-exchanger temperature.
+    .add_dpid_integer(
+        dpid=120,
+        dpcode="temp_radiator",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-30,
+        max=99,
+        scale=0,
+        step=1,
+    )
+    # Electronic expansion valve opening (steps).
+    .add_dpid_integer(
+        dpid=121,
+        dpcode="expansion_valve",
+        dpmode=DPMode.READ,
+        unit="",
+        min=0,
+        max=1000,
+        scale=0,
+        step=1,
+    )
+    # Power-monitoring active flag (semantics inferred).
+    .add_dpid_boolean(
+        dpid=122,
+        dpcode="power_w",
+        dpmode=DPMode.READ,
+    )
+    # Cool-mode enable interlock.
+    .add_dpid_boolean(
+        dpid=123,
+        dpcode="cool_enable",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    # Operating cycle indicator (defrost / heating / standby etc.).
+    .add_dpid_enum(
+        dpid=124,
+        dpcode="oc_mode",
+        dpmode=DPMode.READ,
+        enum_range=["oc_1", "oc_2", "oc_3", "oc_4", "oc_5"],
+    )
+    # Instantaneous power consumption (W).
+    .add_dpid_integer(
+        dpid=125,
+        dpcode="power",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=10000,
+        scale=0,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/qn/__init__.py
+++ b/tests/devices/qn/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya QN category quirks."""

--- a/tests/devices/qn/test_qn_5xe6dkfmdafvrasa.py
+++ b/tests/devices/qn/test_qn_5xe6dkfmdafvrasa.py
@@ -1,0 +1,90 @@
+"""Tests for the Quark/Madimack pool heat pump quirk."""
+
+from tests import create_device
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quark_pool_heat_pump_quirk(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Quirk populates the empty cloud schema with all 25 datapoints."""
+    device = create_device("qn_5xe6dkfmdafvrasa.json")
+
+    assert device.function == {}
+    assert device.status_range == {}
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    # All read-only DPs land in status_range.
+    read_dpcodes = {
+        "switch1",
+        "mode1",
+        "child_lock1",
+        "temp_set1",
+        "work_mode",
+        "temp_unit_convert1",
+        "fault1",
+        "temp_current1",
+        "compressor_strength",
+        "temp_top",
+        "temp_bottom",
+        "temp_coiler",
+        "temp_venting",
+        "temp_effluent",
+        "temp_around",
+        "fault2",
+        "temp_inflow",
+        "temp_return",
+        "temp_coiler_inside",
+        "temp_radiator",
+        "expansion_valve",
+        "power_w",
+        "cool_enable",
+        "oc_mode",
+        "power",
+    }
+    assert read_dpcodes.issubset(device.status_range.keys())
+
+    # Settable DPs also land in function.
+    write_dpcodes = {
+        "switch1",
+        "mode1",
+        "child_lock1",
+        "temp_set1",
+        "work_mode",
+        "temp_unit_convert1",
+        "temp_top",
+        "temp_bottom",
+        "cool_enable",
+    }
+    assert write_dpcodes.issubset(device.function.keys())
+
+
+def test_quark_pool_heat_pump_temperature_scaling(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Inflow/effluent water temps are reported x10; others are whole deg."""
+    device = create_device("qn_5xe6dkfmdafvrasa.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    # x10 scaled water temperatures.
+    assert '"scale": 1' in device.status_range["temp_inflow"].values
+    assert '"scale": 1' in device.status_range["temp_effluent"].values
+
+    # Whole-degree refrigerant temperatures.
+    assert '"scale": 0' in device.status_range["temp_venting"].values
+    assert '"scale": 0' in device.status_range["temp_around"].values
+    assert '"scale": 0' in device.status_range["temp_radiator"].values
+
+
+def test_quark_pool_heat_pump_mode_enum(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """The mode datapoint enumerates heating, cooling and auto."""
+    device = create_device("qn_5xe6dkfmdafvrasa.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    mode = device.function["mode1"]
+    assert '"heating"' in mode.values
+    assert '"cooling"' in mode.values
+    assert '"auto"' in mode.values

--- a/tests/fixtures/devices/qn_5xe6dkfmdafvrasa.json
+++ b/tests/fixtures/devices/qn_5xe6dkfmdafvrasa.json
@@ -1,0 +1,22 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "5xe6dkfmdafvrasa",
+  "category": "qn",
+  "product_id": "5xe6dkfmdafvrasa",
+  "product_name": "Inverter pool Heat pump",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2026-05-04T01:05:49+00:00",
+  "create_time": "2026-05-04T01:05:49+00:00",
+  "update_time": "2026-05-04T01:05:49+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "local_strategy": {},
+  "set_up": true,
+  "support_local": true
+}


### PR DESCRIPTION
## What

Adds the first quirk under a new `qn` (heater) category, covering product_id `5xe6dkfmdafvrasa` — a Quark (夸克) inverter pool heat pump that ships in Australia as the **Madimack Elite V4-120** and is sold under various OEM brands elsewhere.

## Why

Tuya cloud returns empty `function` / `status_range` / `local_strategy` maps for this device. As a result, Home Assistant's Tuya integration builds a single `climate` entity with `hvac_modes: []`, `current_temperature: null` and `supported_features: 0` — completely unusable. Diagnostics excerpt from an affected device:

```json
{
  "category": "qn",
  "product_id": "5xe6dkfmdafvrasa",
  "online": true,
  "mqtt_connected": true,
  "function": {},
  "status_range": {},
  "status": {},
  "home_assistant": {
    "entities": [{
      "entity_id": "climate.inverter_pool_heat_pump",
      "state": "unknown",
      "attributes": {
        "hvac_modes": [],
        "supported_features": 0,
        "current_temperature": null
      }
    }]
  }
}
```

After this quirk is applied, the same device populates 25 datapoints (DPs 101–125) and Home Assistant builds a working climate entity (heat/cool/auto, target temp, inlet water current temp) plus sensors for compressor speed, discharge/ambient/coil/radiator/return temperatures, expansion valve opening, and instantaneous power draw.

## How the DP map was sourced

Datapoint names and types are taken from the **Tuya Developer Portal → Configure Control Instruction Mode → Standard Instruction Set** for product `5xe6dkfmdafvrasa`. The 25 entries are reproduced verbatim as \`dpcode\`s (\`switch1\`, \`mode1\`, \`temp_set1\`, \`work_mode\`, \`temp_unit_convert1\`, \`temp_inflow\`, \`temp_effluent\`, \`temp_around\`, \`compressor_strength\`, \`expansion_valve\`, \`power\`, …) so user-facing names match Tuya's own documentation.

Two of the temperature DPs (\`temp_inflow\`, \`temp_effluent\`) are reported multiplied by 10; everything else is whole degrees. This is captured via \`scale=1\` vs \`scale=0\` and verified by a unit test.

## Verification

This was validated against a physical Madimack Elite V4-120 running current firmware (May 2026) by:

1. Loading the quirk under `<HA config>/tuya_quirks/` and reloading the Tuya integration.
2. Confirming HA built a usable `climate` entity (heat/cool/auto modes, inlet temp 30.5 °C, set temp 34 °C) plus the expected sensors.
3. Cross-checking sensor values against the Tuya app's "Query page" diagnostic screen (inlet 30 °C, outlet 31 °C, ambient 17 °C, discharge 65 °C, radiator 33 °C, EEV 349 steps, 1.38 kW).
4. Confirming an independent Zigbee plug power monitor and the Tuya `power` DP reconcile within ~50 W (the gap matches expected auxiliary/standby load).

## Tests

- \`tests/fixtures/devices/qn_5xe6dkfmdafvrasa.json\` — minimal device fixture with empty cloud maps, mirroring the broken-out-of-the-box state.
- \`tests/devices/qn/test_qn_5xe6dkfmdafvrasa.py\` — three tests covering:
  - All 25 read DPs and 9 write DPs land in \`status_range\` / \`function\` after quirk init
  - \`temp_inflow\`/\`temp_effluent\` carry \`scale=1\`; other temperatures carry \`scale=0\`
  - \`mode1\` enum advertises \`heating\`, \`cooling\`, \`auto\`

Full test suite: 304 passed, coverage 97.09%. \`ruff check\`, \`ruff format\`, \`ty check\`, \`pylint\` (10.00/10), \`codespell\` all green.

## Known unknowns

A few DPs in the Standard Instruction Set were observed but not fully exercised on the test device. Cross-checks from other owners would be appreciated:

- **DP 105 \`work_mode\`** — modelled as \`enum_range=["power", "silent", "smart"]\`. The test device only reported \`"power"\` (its Turbo preset). The other values are educated guesses from common Quark schemas.
- **DP 122 \`power_w\`** — Tuya names this as if it were a wattage reading but the test device reports \`True\`/\`False\`. Modelled as boolean (probably "power-monitoring active" or compressor-energised flag).
- **DP 124 \`oc_mode\`** — only \`"oc_1"\` observed. Extrapolated to \`["oc_1", "oc_2", "oc_3", "oc_4", "oc_5"]\` based on naming; would benefit from observations during defrost / standby cycles.

These can be tightened up in follow-up PRs as more owners report values.

## Notes for reviewers

- This adds the first quirk under \`qn/\`. A \`__init__.py\` is included matching the convention used by \`cl/\`, \`tdq/\`, \`cwwsq/\` (one-line module docstring + link to the relevant Tuya category doc).
- Filename uses the \`qn_\` prefix because the bare product_id starts with a digit, which isn't a valid Python module name.