### PR TITLE
Revert "Add token to coverage upload"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,5 +78,3 @@ jobs:
           poetry run coverage xml -i
       - name: 🚀 Upload coverage report
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

It looks like it was due to a bad configuration on codecov

> This specific project was set to not accept coverage reports without authentication

## Test plan

<!-- How was it tested? -->

Run CI checks

## Related issue

Reverts #189
