### PR TITLE
Fix invalid mock_device type information

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def device_fixture() -> CustomerDevice:
             values="{}",
         ),
         "demo_string": DeviceFunction(
-            code="demo_json",
+            code="demo_string",
             type="String",
             values="{}",
         ),
@@ -160,7 +160,7 @@ def device_fixture() -> CustomerDevice:
             values="{}",
         ),
         "demo_string": DeviceStatusRange(
-            code="demo_json",
+            code="demo_string",
             type="String",
             values="{}",
         ),


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

I spotted this whilst looking to refactor TypeInformation.find_dpcode

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
