### PR TITLE
Add quirk for T & H Sensor (xeagimantb7d7apb)

### DIFF
--- a/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
+++ b/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
@@ -1,9 +1,8 @@
-"""Quirk for Temperature/Humidity sensor (product_id x3o8epevyeo3z3oa).
+"""Quirk for Temperature/Humidity sensor (product_id xeagimantb7d7apb).
 
 Tuya does not advertise any datapoints for this device.
 They have been retrieved from the Tuya Developer Portal.
 
-See https://github.com/home-assistant/core/issues/163360.
 """
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY

--- a/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
+++ b/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
@@ -3,6 +3,7 @@
 Tuya does not advertise any datapoints for this device.
 They have been retrieved from the Tuya Developer Portal.
 
+See https://github.com/home-assistant/core/issues/163947
 """
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY

--- a/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
+++ b/src/tuya_device_handlers/devices/tdq/xeagimantb7d7apb.py
@@ -1,0 +1,49 @@
+"""Quirk for Temperature/Humidity sensor (product_id x3o8epevyeo3z3oa).
+
+Tuya does not advertise any datapoints for this device.
+They have been retrieved from the Tuya Developer Portal.
+
+See https://github.com/home-assistant/core/issues/163360.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="xeagimantb7d7apb")
+    .add_dpid_enum(
+        dpid=20,
+        dpcode="temp_unit_convert",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["c", "f"],
+    )
+    .add_dpid_integer(
+        dpid=27,
+        dpcode="temp_current",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-200,
+        max=600,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=46,
+        dpcode="humidity_value",
+        dpmode=DPMode.READ,
+        unit="%",
+        min=0,
+        max=100,
+        scale=0,
+        step=1,
+    )
+    .add_dpid_enum(
+        dpid=101,
+        dpcode="battery_state",
+        dpmode=DPMode.READ,
+        enum_range=["low", "middle", "high"],
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/tdq/test_xeagimantb7d7apb.py
+++ b/tests/devices/tdq/test_xeagimantb7d7apb.py
@@ -1,0 +1,21 @@
+"""Test device-level quirk initialisation."""
+
+from tests import create_device
+from tuya_device_handlers.definition.sensor import get_default_definition
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_sensor_device_class_override_tdq(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """TDQ quirk registers explicit sensor device classes."""
+    device = create_device("tdq_xeagimantb7d7apb.json")
+    assert get_default_definition(device, "temp_current") is None
+    assert get_default_definition(device, "humidity_value") is None
+    assert get_default_definition(device, "battery_state") is None
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert get_default_definition(device, "temp_current") is not None
+    assert get_default_definition(device, "humidity_value") is not None
+    assert get_default_definition(device, "battery_state") is not None

--- a/tests/fixtures/devices/tdq_xeagimantb7d7apb.json
+++ b/tests/fixtures/devices/tdq_xeagimantb7d7apb.json
@@ -1,0 +1,22 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "xeagimantb7d7apb",
+  "category": "tdq",
+  "product_id": "xeagimantb7d7apb",
+  "product_name": "T & H Sensor",
+  "online": true,
+  "sub": false,
+  "time_zone": "+12:00",
+  "active_time": "2026-05-07T00:36:45+00:00",
+  "create_time": "2026-05-07T00:36:45+00:00",
+  "update_time": "2026-05-07T00:36:45+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "local_strategy": {},
+  "set_up": false,
+  "support_local": true
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

add support for xeagimantb7d7apb T & H Sensor by using x3o8epevyeo3z3oa.py as a example
 
## Test plan

Tested using the recommended steps in the guidelines.
Test Output bellow, unsure if the 2 errors are from the device since its working on home assistant??
<img width="687" height="442" alt="image" src="https://github.com/user-attachments/assets/7fef378a-8efb-41fc-bb08-5eaee429e04c" />


```
PS C:\DEV\tuya-device-handlers> C:\Users\Toino\AppData\Roaming\pypoetry\venv\Scripts\poetry run pytest --cov tuya_device_handlers tests
=========================================================================================================================== test session starts ===========================================================================================================================
platform win32 -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\DEV\tuya-device-handlers
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.3.0, cov-7.1.0, syrupy-5.2.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 331 items

tests\builder\test_device_quirk.py .........................                                                                                                                                                                                                         [  7%]
tests\definition\test_alarm_control_panel.py ..                                                                                                                                                                                                                      [  8%]
tests\definition\test_binary_sensor.py .....                                                                                                                                                                                                                         [  9%]
tests\definition\test_button.py ..                                                                                                                                                                                                                                   [ 10%]
tests\definition\test_camera.py .                                                                                                                                                                                                                                    [ 10%]
tests\definition\test_climate.py ....                                                                                                                                                                                                                                [ 11%]
tests\definition\test_cover.py ..                                                                                                                                                                                                                                    [ 12%]
tests\definition\test_event.py ..                                                                                                                                                                                                                                    [ 12%]
tests\definition\test_fan.py ..                                                                                                                                                                                                                                      [ 13%] 
tests\definition\test_humidifier.py ..                                                                                                                                                                                                                               [ 14%] 
tests\definition\test_init.py .                                                                                                                                                                                                                                      [ 14%] 
tests\definition\test_light.py ...                                                                                                                                                                                                                                   [ 15%]
tests\definition\test_number.py ..                                                                                                                                                                                                                                   [ 16%] 
tests\definition\test_select.py ..                                                                                                                                                                                                                                   [ 16%] 
tests\definition\test_sensor.py .......                                                                                                                                                                                                                              [ 18%]
tests\definition\test_siren.py ..                                                                                                                                                                                                                                    [ 19%] 
tests\definition\test_switch.py ..                                                                                                                                                                                                                                   [ 19%] 
tests\definition\test_vacuum.py .                                                                                                                                                                                                                                    [ 20%]
tests\definition\test_valve.py ..                                                                                                                                                                                                                                    [ 20%] 
tests\device_wrapper\test_alarm_control_panel.py ...........                                                                                                                                                                                                         [ 24%]
tests\device_wrapper\test_base.py .                                                                                                                                                                                                                                  [ 24%] 
tests\device_wrapper\test_binary_sensor.py ..........                                                                                                                                                                                                                [ 27%]
tests\device_wrapper\test_climate.py ......................                                                                                                                                                                                                          [ 34%]
tests\device_wrapper\test_common.py .................                                                                                                                                                                                                                [ 39%]
tests\device_wrapper\test_cover.py ...............                                                                                                                                                                                                                   [ 43%]
tests\device_wrapper\test_event.py ...                                                                                                                                                                                                                               [ 44%] 
tests\device_wrapper\test_extended.py ...........                                                                                                                                                                                                                    [ 48%]
tests\device_wrapper\test_fan.py ............                                                                                                                                                                                                                        [ 51%]
tests\device_wrapper\test_light.py ....................                                                                                                                                                                                                              [ 57%]
tests\device_wrapper\test_sensor.py ................                                                                                                                                                                                                                 [ 62%]
tests\device_wrapper\test_service_feeder_schedule.py .........                                                                                                                                                                                                       [ 65%]
tests\device_wrapper\test_vacuum.py ...............                                                                                                                                                                                                                  [ 69%]
tests\devices\cl\test_b9oa3zocv4qq47iy.py ..                                                                                                                                                                                                                         [ 70%]
tests\devices\cwwsq\test_wfkzyy0evslzsmoi.py .....                                                                                                                                                                                                                   [ 71%]
tests\devices\tdq\test_p6sqiuesvhmhvv4f.py ..                                                                                                                                                                                                                        [ 72%] 
tests\devices\tdq\test_x3o8epevyeo3z3oa.py .                                                                                                                                                                                                                         [ 72%] 
tests\devices\tdq\test_xeagimantb7d7apb.py .                                                                                                                                                                                                                         [ 73%] 
tests\helpers\test_diagnostics.py .FF                                                                                                                                                                                                                                [ 74%]
tests\test_const.py ..............                                                                                                                                                                                                                                   [ 78%]
tests\test_fixtures.py ........................                                                                                                                                                                                                                      [ 85%]
tests\test_raw_data_model.py ...............                                                                                                                                                                                                                         [ 90%]
tests\test_registry.py ....                                                                                                                                                                                                                                          [ 91%]
tests\test_type_information.py ..........................                                                                                                                                                                                                            [ 99%]
tests\test_utils.py ...                                                                                                                                                                                                                                              [100%]

================================================================================================================================ FAILURES ================================================================================================================================= 
_________________________________________________________________________________________________________________ test_customer_device_with_quirk_as_dict _________________________________________________________________________________________________________________ 

filled_quirks_registry = <tuya_device_handlers.registry.QuirksRegistry object at 0x000001EAE37E7CB0>
snapshot = dict({
  'active_time': '2026-05-07T00:36:45+00:00',
  'category': 'tdq',
  'create_time': '2026-05-07T00:36:45+00:00'...
  'support_local': True,
  'time_zone': '+12:00',
  'update_time': '2026-05-07T00:36:45+00:00',
  'warnings': None,
})

    def test_customer_device_with_quirk_as_dict(
        filled_quirks_registry: QuirksRegistry, snapshot: SnapshotAssertion
    ) -> None:
        """Test customer_device_as_dict."""
        device = create_device("tdq_x3o8epevyeo3z3oa.json")

        filled_quirks_registry.initialise_device_quirk(device)

        data = customer_device_as_dict(device)
        data["quirk"] = _relative_quirk(data["quirk"])
>       assert data == snapshot
E       AssertionError: assert [+ received] == [- snapshot]
E           dict({
E            ...
E             'product_name': 'T & H Sensor',
E         -   'quirk': 'src
E
E         ...Full output truncated (5 lines hidden), use '-vv' to show

tests\helpers\test_diagnostics.py:43: AssertionError
__________________________________________________________________________________________________________ test_customer_device_with_uninitialised_quirk_as_dict __________________________________________________________________________________________________________ 

snapshot = dict({
  'active_time': '2026-05-07T00:36:45+00:00',
  'category': 'tdq',
  'create_time': '2026-05-07T00:36:45+00:00'...
  'support_local': True,
  'time_zone': '+12:00',
  'update_time': '2026-05-07T00:36:45+00:00',
  'warnings': None,
})

    def test_customer_device_with_uninitialised_quirk_as_dict(
        snapshot: SnapshotAssertion,
    ) -> None:
        """Test customer_device_as_dict when the quirk was not initialised.

        A quirk is registered for the device, but initialise_device was
        never called, so the original_* attributes are absent.
        """
        device = create_device("tdq_x3o8epevyeo3z3oa.json")

        # auto_reset_quirks reverts this registration after the test.
        (
            DeviceQuirk()
            .applies_to(product_id=device.product_id)
            .register(TUYA_QUIRKS_REGISTRY)
        )

        data = customer_device_as_dict(device)
        data["quirk"] = _relative_quirk(data["quirk"])
>       assert data == snapshot
E       AssertionError: assert [+ received] == [- snapshot]
E           dict({
E            ...
E             'product_name': 'T & H Sensor',
E         -   'quirk': 'tes...
E
E         ...Full output truncated (5 lines hidden), use '-vv' to show

tests\helpers\test_diagnostics.py:69: AssertionError
============================================================================================================================= tests coverage ============================================================================================================================== 
_____________________________________________________________________________________________________________ coverage: platform win32, python 3.14.5-final-0 _____________________________________________________________________________________________________________ 

Name                                                                 Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------------------------------------
src\tuya_device_handlers\definition\climate.py                          42      1     14      1    96%   109
src\tuya_device_handlers\definition\light.py                            50      9     14      4    77%   119-120, 128-129, 149, 167-174
src\tuya_device_handlers\device_wrapper\common.py                       67      1      4      0    99%   57
src\tuya_device_handlers\device_wrapper\service_feeder_schedule.py     101      0     24      3    98%   130->129, 177->176, 236->233
src\tuya_device_handlers\devices\__init__.py                            32     16     10      2    48%   24, 37-64
src\tuya_device_handlers\helpers\utils.py                                8      6      2      0    20%   12-17
----------------------------------------------------------------------------------------------------------------
TOTAL                                                                 1761     33    338     10    98%

49 files skipped due to complete coverage.
Required test coverage of 90.0% reached. Total coverage: 97.57%
------------------------------------------------------------------------------------------------------------------------- snapshot report summary ------------------------------------------------------------------------------------------------------------------------- 
2 snapshots failed. 39 snapshots passed.
========================================================================================================================= short test summary info ========================================================================================================================= 
FAILED tests/helpers/test_diagnostics.py::test_customer_device_with_quirk_as_dict - AssertionError: assert [+ received] == [- snapshot]
FAILED tests/helpers/test_diagnostics.py::test_customer_device_with_uninitialised_quirk_as_dict - AssertionError: assert [+ received] == [- snapshot]
====================================================================================================================== 2 failed, 329 passed in 1.23s ====================================================================================================================== 
PS C:\DEV\tuya-device-handlers> C:\Users\Toino\AppData\Roaming\pypoetry\venv\Scripts\poetry run ruff check .                           
All checks passed!
PS C:\DEV\tuya-device-handlers> C:\Users\Toino\AppData\Roaming\pypoetry\venv\Scripts\poetry run ty check src tests
All checks passed!
PS C:\DEV\tuya-device-handlers>
```

## Related issue

Possible fix for https://github.com/home-assistant/core/issues/163947
