### PR TITLE
Add get_type_information helper

### DIFF
--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -67,23 +67,13 @@ class TypeInformation[T](abc.ABC):
         prefer_function: bool = False,
     ) -> Self | None:
         """Find type information for a matching DP code."""
-        if dpcodes is None:
-            return None
-
-        if not isinstance(dpcodes, tuple):
-            dpcodes = (dpcodes,)
-
-        for dpcode in dpcodes:
-            if type_information := get_device_dpcode_type_information(
-                device=device,
-                dpcode=dpcode,
-                prefer_function=prefer_function,
-                dp_type=cls._DPTYPE,
-                type_information_cls=cls,
-            ):
-                return type_information
-
-        return None
+        return get_device_dpcode_type_information(
+            device,
+            dpcodes,
+            prefer_function=prefer_function,
+            dp_type=cls._DPTYPE,
+            type_information_cls=cls,
+        )
 
     @abc.abstractmethod
     def read_device_value(self, device: CustomerDevice) -> T | None:
@@ -346,6 +336,34 @@ class StringTypeInformation(TypeInformation[str]):
 
 def get_device_dpcode_type_information[T: TypeInformation](
     device: CustomerDevice,
+    dpcodes: str | tuple[str, ...] | None,
+    *,
+    prefer_function: bool = False,
+    dp_type: DPType,
+    type_information_cls: type[T],
+) -> T | None:
+    """Find type information for a device DP code."""
+    if dpcodes is None:
+        return None
+
+    if not isinstance(dpcodes, tuple):
+        dpcodes = (dpcodes,)
+
+    for dpcode in dpcodes:
+        if type_information := _get_device_dpcode_type_information(
+            device=device,
+            dpcode=dpcode,
+            prefer_function=prefer_function,
+            dp_type=dp_type,
+            type_information_cls=type_information_cls,
+        ):
+            return type_information
+
+    return None
+
+
+def _get_device_dpcode_type_information[T: TypeInformation](
+    device: CustomerDevice,
     dpcode: str,
     *,
     prefer_function: bool = False,
@@ -353,30 +371,34 @@ def get_device_dpcode_type_information[T: TypeInformation](
     type_information_cls: type[T],
 ) -> T | None:
     """Find type information for a device DP code."""
+    # Get definitions
     function_definition = device.function.get(dpcode)
+    status_range_definition = device.status_range.get(dpcode)
+
+    # Validate definitions against expected DP type, ignore if not matching
     if (
         function_definition
         and DPType.try_parse(function_definition.type) is not dp_type
     ):
         function_definition = None
 
-    status_range_definition = device.status_range.get(dpcode)
     if (
         status_range_definition
         and DPType.try_parse(status_range_definition.type) is not dp_type
     ):
         status_range_definition = None
 
+    # report_type is not available on function definitions
+    report_type = (
+        status_range_definition.report_type if status_range_definition else None
+    )
+
+    # Get type_information based on definition preference
     lookup = (
         (function_definition, status_range_definition)
         if prefer_function
         else (status_range_definition, function_definition)
     )
-
-    report_type = (
-        status_range_definition.report_type if status_range_definition else None
-    )
-
     for definition in lookup:
         if definition is not None and (
             type_information := type_information_cls._from_json(  # noqa: SLF001

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -67,7 +67,7 @@ class TypeInformation[T](abc.ABC):
         prefer_function: bool = False,
     ) -> Self | None:
         """Find type information for a matching DP code."""
-        return get_device_dpcode_type_information(
+        return get_type_information(
             device,
             dpcodes,
             prefer_function=prefer_function,
@@ -333,7 +333,7 @@ class StringTypeInformation(TypeInformation[str]):
         return cast(str, device.status.get(self.dpcode))
 
 
-def get_device_dpcode_type_information[T: TypeInformation](
+def get_type_information[T: TypeInformation](
     device: CustomerDevice,
     dpcodes: str | tuple[str, ...] | None,
     *,

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -401,6 +401,7 @@ def _get_device_dpcode_type_information[T: TypeInformation](
     )
     for definition in lookup:
         if definition is not None and (
+            # pylint: disable-next=protected-access
             type_information := type_information_cls._from_json(  # noqa: SLF001
                 dpcode=dpcode,
                 type_data=definition.values,

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -71,7 +71,6 @@ class TypeInformation[T](abc.ABC):
             device,
             dpcodes,
             prefer_function=prefer_function,
-            dp_type=cls._DPTYPE,
             type_information_cls=cls,
         )
 
@@ -339,7 +338,6 @@ def get_device_dpcode_type_information[T: TypeInformation](
     dpcodes: str | tuple[str, ...] | None,
     *,
     prefer_function: bool = False,
-    dp_type: DPType,
     type_information_cls: type[T],
 ) -> T | None:
     """Find type information for a device DP code."""
@@ -354,7 +352,6 @@ def get_device_dpcode_type_information[T: TypeInformation](
             device=device,
             dpcode=dpcode,
             prefer_function=prefer_function,
-            dp_type=dp_type,
             type_information_cls=type_information_cls,
         ):
             return type_information
@@ -367,7 +364,6 @@ def _get_device_dpcode_type_information[T: TypeInformation](
     dpcode: str,
     *,
     prefer_function: bool = False,
-    dp_type: DPType,
     type_information_cls: type[T],
 ) -> T | None:
     """Find type information for a device DP code."""
@@ -376,6 +372,8 @@ def _get_device_dpcode_type_information[T: TypeInformation](
     status_range_definition = device.status_range.get(dpcode)
 
     # Validate definitions against expected DP type, ignore if not matching
+    # pylint: disable-next=protected-access
+    dp_type = type_information_cls._DPTYPE  # noqa: SLF001
     if (
         function_definition
         and DPType.try_parse(function_definition.type) is not dp_type

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -73,31 +73,15 @@ class TypeInformation[T](abc.ABC):
         if not isinstance(dpcodes, tuple):
             dpcodes = (dpcodes,)
 
-        lookup_tuple = (
-            (device.function, device.status_range)
-            if prefer_function
-            else (device.status_range, device.function)
-        )
-
         for dpcode in dpcodes:
-            report_type = (
-                status_range.report_type
-                if (status_range := device.status_range.get(dpcode))
-                else None
-            )
-            for device_specs in lookup_tuple:
-                if (
-                    (current_definition := device_specs.get(dpcode))
-                    and DPType.try_parse(current_definition.type) is cls._DPTYPE
-                    and (
-                        type_information := cls._from_json(
-                            dpcode=dpcode,
-                            type_data=current_definition.values,
-                            report_type=report_type,
-                        )
-                    )
-                ):
-                    return type_information
+            if type_information := get_device_dpcode_type_information(
+                device=device,
+                dpcode=dpcode,
+                prefer_function=prefer_function,
+                dp_type=cls._DPTYPE,
+                type_information_cls=cls,
+            ):
+                return type_information
 
         return None
 
@@ -358,3 +342,49 @@ class StringTypeInformation(TypeInformation[str]):
     def read_device_value(self, device: CustomerDevice) -> str | None:
         """Read the device value for this datapoint."""
         return cast(str, device.status.get(self.dpcode))
+
+
+def get_device_dpcode_type_information[T: TypeInformation](
+    device: CustomerDevice,
+    dpcode: str,
+    *,
+    prefer_function: bool = False,
+    dp_type: DPType,
+    type_information_cls: type[T],
+) -> T | None:
+    """Find type information for a device DP code."""
+    function_definition = device.function.get(dpcode)
+    if (
+        function_definition
+        and DPType.try_parse(function_definition.type) is not dp_type
+    ):
+        function_definition = None
+
+    status_range_definition = device.status_range.get(dpcode)
+    if (
+        status_range_definition
+        and DPType.try_parse(status_range_definition.type) is not dp_type
+    ):
+        status_range_definition = None
+
+    lookup = (
+        (function_definition, status_range_definition)
+        if prefer_function
+        else (status_range_definition, function_definition)
+    )
+
+    report_type = (
+        status_range_definition.report_type if status_range_definition else None
+    )
+
+    for definition in lookup:
+        if definition is not None and (
+            type_information := type_information_cls._from_json(  # noqa: SLF001
+                dpcode=dpcode,
+                type_data=definition.values,
+                report_type=report_type,
+            )
+        ):
+            return type_information
+
+    return None


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Add a new helper `get_device_dpcode_type_information`, to replace the classmethod `TypeInformation.find_dpcode`

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
