### PR TITLE
Guard against circular imports in registry

### DIFF
--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -1,13 +1,17 @@
 """Quirks registry."""
 
+from __future__ import annotations
+
 import logging
-import pathlib
-from typing import Any, Protocol, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self
 
-from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
+if TYPE_CHECKING:
+    import pathlib
 
-from .device_wrapper.base import DeviceWrapper
-from .device_wrapper.service_feeder_schedule import FeederSchedule
+    from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
+
+    from .device_wrapper.base import DeviceWrapper
+    from .device_wrapper.service_feeder_schedule import FeederSchedule
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/tuya_device_handlers/registry.py
+++ b/src/tuya_device_handlers/registry.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
     from tuya_sharing import CustomerDevice, DeviceFunction, DeviceStatusRange
 
+    # We don't want to accidentally create a circular import, so we import
+    # these here for type checking only
     from .device_wrapper.base import DeviceWrapper
     from .device_wrapper.service_feeder_schedule import FeederSchedule
 


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

We don't want to import any other module when we generate TUYA_QUIRKS_REGISTRY

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

Spotted in #201
