### PR TITLE
Fix check-added-large-files in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: check-added-large-files
         name: Check for added large files
-        entry: check-added-large-files
+        entry: poetry run check-added-large-files
         language: system
       - id: check-ast
         name: Check Python AST


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Ensure `check-added-large-files` is run inside poetry

## Test plan

<!-- How was it tested? -->

Local test

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
