### PR TITLE
Adjust devcontainer default interpreter path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,12 +29,12 @@
         "coverage-gutters.showLineCoverage": true,
         "coverage-gutters.xmlname": "coverage.xml",
         "python.analysis.extraPaths": ["${workspaceFolder}/src"],
-        "python.defaultInterpreterPath": ".venv/bin/python",
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
         "python.testing.cwd": "${workspaceFolder}",
         "python.testing.pytestArgs": ["--cov-report=xml"],
         "python.testing.pytestEnabled": true,
         "ruff.importStrategy": "fromEnvironment",
-        "ruff.interpreter": [".venv/bin/python"],
+        "ruff.interpreter": ["${workspaceFolder}/.venv/bin/python"],
         "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,8 @@
       "settings": {
         "[python]": {
           "editor.codeActionsOnSave": {
-            "source.fixAll": true,
-            "source.organizeImports": true
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
           }
         },
         "coverage-gutters.customizable.context-menu": true,
@@ -40,7 +40,7 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers-contrib/features/poetry:2": {},
+    "ghcr.io/devcontainers-extra/features/poetry:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:2": {},
     "ghcr.io/devcontainers/features/python:1": {


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

On my machine it fails to find the interpreter in `".venv/bin/python"`
Make the root explicit with "`${workspaceFolder}/.venv/bin/python`"

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
