### PR TITLE
Add quirk reference to TypeInformation

### DIFF
--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -140,7 +140,8 @@ class BitmapTypeInformation(TypeInformation[int]):
         report_type: str | None,
     ) -> Self | None:
         """Load JSON string and return a BitmapTypeInformation object."""
-        if not (parsed := cast(dict[str, Any] | None, json.loads(type_data))):
+        parsed: dict[str, Any] | None
+        if not (parsed := json.loads(type_data)):
             return None
         return cls(
             dpcode=dpcode,
@@ -222,13 +223,14 @@ class EnumTypeInformation(TypeInformation[str]):
         report_type: str | None,
     ) -> Self | None:
         """Load JSON string and return an EnumTypeInformation object."""
+        parsed: dict[str, Any] | None
         if not (parsed := json.loads(type_data)):
             return None
         return cls(
             dpcode=dpcode,
             type_data=type_data,
             report_type=report_type,
-            **cast(dict[str, list[str]], parsed),
+            range=parsed["range"],
         )
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> str:
@@ -290,7 +292,8 @@ class IntegerTypeInformation(TypeInformation[float]):
         cls, dpcode: str, type_data: str, *, report_type: str | None
     ) -> Self | None:
         """Load JSON string and return an IntegerTypeInformation object."""
-        if not (parsed := cast(dict[str, Any] | None, json.loads(type_data))):
+        parsed: dict[str, Any] | None
+        if not (parsed := json.loads(type_data)):
             return None
 
         return cls(

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -10,7 +10,9 @@ from typing import Any, ClassVar, Self, cast
 
 from tuya_sharing import CustomerDevice
 
+from . import TUYA_QUIRKS_REGISTRY
 from .const import DEVICE_WARNINGS, DPType
+from .registry import DeviceQuirkProtocol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,6 +48,7 @@ class TypeInformation[T](abc.ABC):
     dpcode: str
     type_data: str
     report_type: str | None
+    quirk: DeviceQuirkProtocol | None = None
 
     @classmethod
     def _from_json(
@@ -78,6 +81,7 @@ class TypeInformation[T](abc.ABC):
             if prefer_function
             else (device.status_range, device.function)
         )
+        quirk = TUYA_QUIRKS_REGISTRY.get_quirk_for_device(device)
 
         for dpcode in dpcodes:
             report_type = (
@@ -97,6 +101,7 @@ class TypeInformation[T](abc.ABC):
                         )
                     )
                 ):
+                    type_information.quirk = quirk
                     return type_information
 
         return None

--- a/tests/__snapshots__/test_type_information.ambr
+++ b/tests/__snapshots__/test_type_information.ambr
@@ -5,6 +5,7 @@
     'label': list([
       'motor_fault',
     ]),
+    'quirk': None,
     'report_type': None,
     'type_data': '{"label": ["motor_fault"]}',
   })
@@ -12,6 +13,7 @@
 # name: test_valid_type_information[BooleanTypeInformation-demo_boolean]
   dict({
     'dpcode': 'demo_boolean',
+    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -19,6 +21,7 @@
 # name: test_valid_type_information[EnumTypeInformation-demo_enum]
   dict({
     'dpcode': 'demo_enum',
+    'quirk': None,
     'range': list([
       'scene',
       'customize_scene',
@@ -33,6 +36,7 @@
     'dpcode': 'demo_integer',
     'max': 1000,
     'min': 0,
+    'quirk': None,
     'report_type': None,
     'scale': 1,
     'step': 1,
@@ -43,6 +47,7 @@
 # name: test_valid_type_information[JsonTypeInformation-demo_json]
   dict({
     'dpcode': 'demo_json',
+    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -50,6 +55,7 @@
 # name: test_valid_type_information[RawTypeInformation-demo_raw]
   dict({
     'dpcode': 'demo_raw',
+    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -57,6 +63,7 @@
 # name: test_valid_type_information[StringTypeInformation-demo_string]
   dict({
     'dpcode': 'demo_string',
+    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })

--- a/tests/__snapshots__/test_type_information.ambr
+++ b/tests/__snapshots__/test_type_information.ambr
@@ -5,7 +5,6 @@
     'label': list([
       'motor_fault',
     ]),
-    'quirk': None,
     'report_type': None,
     'type_data': '{"label": ["motor_fault"]}',
   })
@@ -13,7 +12,6 @@
 # name: test_valid_type_information[BooleanTypeInformation-demo_boolean]
   dict({
     'dpcode': 'demo_boolean',
-    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -21,7 +19,6 @@
 # name: test_valid_type_information[EnumTypeInformation-demo_enum]
   dict({
     'dpcode': 'demo_enum',
-    'quirk': None,
     'range': list([
       'scene',
       'customize_scene',
@@ -36,7 +33,6 @@
     'dpcode': 'demo_integer',
     'max': 1000,
     'min': 0,
-    'quirk': None,
     'report_type': None,
     'scale': 1,
     'step': 1,
@@ -47,7 +43,6 @@
 # name: test_valid_type_information[JsonTypeInformation-demo_json]
   dict({
     'dpcode': 'demo_json',
-    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -55,7 +50,6 @@
 # name: test_valid_type_information[RawTypeInformation-demo_raw]
   dict({
     'dpcode': 'demo_raw',
-    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })
@@ -63,7 +57,6 @@
 # name: test_valid_type_information[StringTypeInformation-demo_string]
   dict({
     'dpcode': 'demo_string',
-    'quirk': None,
     'report_type': None,
     'type_data': '{}',
   })

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -2,12 +2,13 @@
 
 import dataclasses
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.const import DEVICE_WARNINGS
 from tuya_device_handlers.type_information import (
     BitmapTypeInformation,
@@ -74,6 +75,29 @@ def test_invalid_type_information(
     type_information = type_information_type.find_dpcode(mock_device, dpcode)
 
     assert type_information is None
+
+
+def test_quirk_set_when_registered(mock_device: CustomerDevice) -> None:
+    """find_dpcode attaches the device's quirk to the type information."""
+    quirk = Mock()
+    TUYA_QUIRKS_REGISTRY.register(mock_device.product_id, quirk)
+
+    type_information = StringTypeInformation.find_dpcode(
+        mock_device, "demo_string"
+    )
+
+    assert type_information
+    assert type_information.quirk is quirk
+
+
+def test_quirk_none_when_not_registered(mock_device: CustomerDevice) -> None:
+    """find_dpcode leaves quirk as None when no quirk is registered."""
+    type_information = StringTypeInformation.find_dpcode(
+        mock_device, "demo_string"
+    )
+
+    assert type_information
+    assert type_information.quirk is None
 
 
 def test_integer_scaling(mock_device: CustomerDevice) -> None:

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
 from tuya_sharing import CustomerDevice
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
@@ -45,7 +46,9 @@ def test_valid_type_information(
     type_information = type_information_type.find_dpcode(mock_device, dpcode)
 
     assert type_information
-    assert dataclasses.asdict(type_information) == snapshot
+    assert dataclasses.asdict(type_information) == snapshot(
+        exclude=props("quirk")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Add a reference to the quirk in TypeInformation, so transformation can be added in a follow-up PR.

## Test plan

<!-- How was it tested? -->

Tests added to pytest

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
