### PR TITLE
Move set-value preparation into TypeInformation

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/common.py
+++ b/src/tuya_device_handlers/device_wrapper/common.py
@@ -1,6 +1,6 @@
 """Tuya device wrapper."""
 
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
 from tuya_sharing import CustomerDevice
 
@@ -10,6 +10,7 @@ from tuya_device_handlers.type_information import (
     EnumTypeInformation,
     IntegerTypeInformation,
     JsonTypeInformation,
+    PrepareSetValueError,
     RawTypeInformation,
     StringTypeInformation,
     TypeInformation,
@@ -118,6 +119,15 @@ class DPCodeTypeInformationWrapper[
         """Read and process raw value against this type information."""
         return self.type_information.read_device_value(device)
 
+    def _convert_value_to_raw_value(
+        self, device: CustomerDevice, value: Any
+    ) -> Any:
+        """Convert a Home Assistant value back to a raw device value."""
+        try:
+            return self.type_information.prepare_set_value(device, value)
+        except PrepareSetValueError as err:
+            raise SetValueOutOfRangeError(str(err)) from err
+
 
 class DPCodeBitmapWrapper[T = int](
     DPCodeTypeInformationWrapper[BitmapTypeInformation, int, T]
@@ -134,20 +144,6 @@ class DPCodeBooleanWrapper[T = bool](
 
     _DPTYPE = BooleanTypeInformation
 
-    def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> bool:
-        """Convert a Home Assistant value back to a raw device value."""
-        if value in (True, False):
-            if TYPE_CHECKING:
-                # Type checkers don't infer membership in a tuple of bools
-                assert isinstance(value, bool)
-            return value
-        # Currently only called with boolean values
-        # Safety net in case of future changes
-        msg = f"Invalid boolean value `{value}`"
-        raise SetValueOutOfRangeError(msg)
-
 
 class DPCodeEnumWrapper[T = str](
     DPCodeTypeInformationWrapper[EnumTypeInformation, str, T]
@@ -163,22 +159,6 @@ class DPCodeEnumWrapper[T = str](
         """Init DPCodeEnumWrapper."""
         super().__init__(dpcode, type_information)
         self.options = type_information.range
-
-    def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> str:
-        """Convert a Home Assistant value back to a raw device value."""
-        if value in self.type_information.range:
-            if TYPE_CHECKING:
-                # Type checkers don't infer membership in a list of strings
-                assert isinstance(value, str)
-            return value
-        # Guarded by select option validation
-        # Safety net in case of future changes
-        msg = (
-            f"Enum value `{value}` out of range: {self.type_information.range}"
-        )
-        raise SetValueOutOfRangeError(msg)
 
 
 class DPCodeIntegerWrapper[T = float](
@@ -199,21 +179,6 @@ class DPCodeIntegerWrapper[T = float](
         self.value_step = self.type_information.scale_value(
             type_information.step
         )
-
-    def _convert_value_to_raw_value(
-        self, device: CustomerDevice, value: Any
-    ) -> int:
-        """Convert a Home Assistant value back to a raw device value."""
-        new_value = self.type_information.scale_value_back(value)
-        if self.type_information.min <= new_value <= self.type_information.max:
-            return new_value
-        # Guarded by number validation
-        # Safety net in case of future changes
-        msg = (
-            f"Value `{new_value}` (converted from `{value}`) out of range:"
-            f" ({self.type_information.min}-{self.type_information.max})"
-        )
-        raise SetValueOutOfRangeError(msg)
 
 
 class DPCodeJsonWrapper[T = dict[str, Any]](

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -20,6 +20,10 @@ _LOG_OR_QUIRK = (
 )
 
 
+class PrepareSetValueError(ValueError):
+    """A value could not be prepared to be sent to a Tuya data point."""
+
+
 def _should_log_warning(device_id: str, warning_key: str) -> bool:
     """Check if a warning was already logged for a device.
 
@@ -105,6 +109,14 @@ class TypeInformation[T](abc.ABC):
     def read_device_value(self, device: CustomerDevice) -> T | None:
         """Read (and validate + convert) device value."""
 
+    def prepare_set_value(self, device: CustomerDevice, value: Any) -> Any:
+        """Prepare a Home Assistant value to be sent as a device command.
+
+        Base implementation does no conversion, subclasses may
+        override to provide specific conversion and validation.
+        """
+        raise NotImplementedError
+
 
 @dataclass(kw_only=True)
 class BitmapTypeInformation(TypeInformation[int]):
@@ -159,6 +171,15 @@ class BooleanTypeInformation(TypeInformation[bool]):
 
     _DPTYPE = DPType.BOOLEAN
 
+    def prepare_set_value(self, device: CustomerDevice, value: Any) -> bool:
+        """Prepare a Home Assistant value to be sent as a device command."""
+        if value in (True, False):
+            return cast(bool, value)
+        # Currently only called with boolean values
+        # Safety net in case of future changes
+        msg = f"Invalid boolean value `{value}`"
+        raise PrepareSetValueError(msg)
+
     def read_device_value(self, device: CustomerDevice) -> bool | None:
         """Read the device value for this datapoint."""
         if (raw_value := device.status.get(self.dpcode)) is None:
@@ -206,6 +227,15 @@ class EnumTypeInformation(TypeInformation[str]):
             report_type=report_type,
             **cast(dict[str, list[str]], parsed),
         )
+
+    def prepare_set_value(self, device: CustomerDevice, value: Any) -> str:
+        """Prepare a Home Assistant value to be sent as a device command."""
+        if value in self.range:
+            return cast(str, value)
+        # Guarded by select option validation
+        # Safety net in case of future changes
+        msg = f"Enum value `{value}` out of range: {self.range}"
+        raise PrepareSetValueError(msg)
 
     def read_device_value(self, device: CustomerDevice) -> str | None:
         """Read the device value for this datapoint."""
@@ -269,6 +299,19 @@ class IntegerTypeInformation(TypeInformation[float]):
             unit=parsed.get("unit"),
             report_type=report_type,
         )
+
+    def prepare_set_value(self, device: CustomerDevice, value: Any) -> int:
+        """Prepare a Home Assistant value to be sent as a device command."""
+        new_value = self.scale_value_back(value)
+        if self.min <= new_value <= self.max:
+            return new_value
+        # Guarded by number validation
+        # Safety net in case of future changes
+        msg = (
+            f"Value `{new_value}` (converted from `{value}`) out of range:"
+            f" ({self.min}-{self.max})"
+        )
+        raise PrepareSetValueError(msg)
 
     def read_device_value(self, device: CustomerDevice) -> float | None:
         """Read the device value for this datapoint."""

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -173,8 +173,8 @@ class BooleanTypeInformation(TypeInformation[bool]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> bool:
         """Prepare a Home Assistant value to be sent as a device command."""
-        if value in (True, False):
-            return cast(bool, value)
+        if isinstance(value, bool):
+            return value
         # Currently only called with boolean values
         # Safety net in case of future changes
         msg = f"Invalid boolean value `{value}`"
@@ -230,8 +230,8 @@ class EnumTypeInformation(TypeInformation[str]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> str:
         """Prepare a Home Assistant value to be sent as a device command."""
-        if value in self.range:
-            return cast(str, value)
+        if isinstance(value, str) and value in self.range:
+            return value
         # Guarded by select option validation
         # Safety net in case of future changes
         msg = f"Enum value `{value}` out of range: {self.range}"
@@ -302,9 +302,10 @@ class IntegerTypeInformation(TypeInformation[float]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> int:
         """Prepare a Home Assistant value to be sent as a device command."""
-        new_value = self.scale_value_back(value)
-        if self.min <= new_value <= self.max:
-            return new_value
+        if isinstance(value, float):
+            new_value = self.scale_value_back(value)
+            if self.min <= new_value <= self.max:
+                return new_value
         # Guarded by number validation
         # Safety net in case of future changes
         msg = (

--- a/src/tuya_device_handlers/type_information.py
+++ b/src/tuya_device_handlers/type_information.py
@@ -173,12 +173,10 @@ class BooleanTypeInformation(TypeInformation[bool]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> bool:
         """Prepare a Home Assistant value to be sent as a device command."""
-        if isinstance(value, bool):
-            return value
-        # Currently only called with boolean values
-        # Safety net in case of future changes
-        msg = f"Invalid boolean value `{value}`"
-        raise PrepareSetValueError(msg)
+        if not isinstance(value, bool):
+            msg = f"Invalid boolean value `{value}` ({type(value).__name__})"
+            raise PrepareSetValueError(msg)
+        return value
 
     def read_device_value(self, device: CustomerDevice) -> bool | None:
         """Read the device value for this datapoint."""
@@ -230,12 +228,13 @@ class EnumTypeInformation(TypeInformation[str]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> str:
         """Prepare a Home Assistant value to be sent as a device command."""
-        if isinstance(value, str) and value in self.range:
-            return value
-        # Guarded by select option validation
-        # Safety net in case of future changes
-        msg = f"Enum value `{value}` out of range: {self.range}"
-        raise PrepareSetValueError(msg)
+        if not isinstance(value, str):
+            msg = f"Invalid string value `{value}` ({type(value).__name__})"
+            raise PrepareSetValueError(msg)
+        if value not in self.range:
+            msg = f"Enum value `{value}` out of range: {self.range}"
+            raise PrepareSetValueError(msg)
+        return value
 
     def read_device_value(self, device: CustomerDevice) -> str | None:
         """Read the device value for this datapoint."""
@@ -302,17 +301,17 @@ class IntegerTypeInformation(TypeInformation[float]):
 
     def prepare_set_value(self, device: CustomerDevice, value: Any) -> int:
         """Prepare a Home Assistant value to be sent as a device command."""
-        if isinstance(value, float):
-            new_value = self.scale_value_back(value)
-            if self.min <= new_value <= self.max:
-                return new_value
-        # Guarded by number validation
-        # Safety net in case of future changes
-        msg = (
-            f"Value `{new_value}` (converted from `{value}`) out of range:"
-            f" ({self.min}-{self.max})"
-        )
-        raise PrepareSetValueError(msg)
+        if not isinstance(value, (int, float)):
+            msg = f"Invalid numeric value `{value}` ({type(value).__name__})"
+            raise PrepareSetValueError(msg)
+        new_value = self.scale_value_back(value)
+        if not (self.min <= new_value <= self.max):
+            msg = (
+                f"Value `{new_value}` (converted from {type(value).__name__}"
+                f" `{value}`) out of range: ({self.min}-{self.max})"
+            )
+            raise PrepareSetValueError(msg)
+        return new_value
 
     def read_device_value(self, device: CustomerDevice) -> float | None:
         """Read the device value for this datapoint."""

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -246,25 +246,3 @@ def test_prepare_set_value_out_of_range(
     assert type_information
     with pytest.raises(PrepareSetValueError, match=match):
         type_information.prepare_set_value(mock_device, value)
-
-
-@pytest.mark.parametrize(
-    ("type_information_type", "dpcode"),
-    [
-        (BitmapTypeInformation, "demo_bitmap"),
-        (JsonTypeInformation, "demo_json"),
-        (RawTypeInformation, "demo_raw"),
-        (StringTypeInformation, "demo_string"),
-    ],
-)
-def test_prepare_set_value_not_implemented(
-    type_information_type: type[TypeInformation[Any]],
-    dpcode: str,
-    mock_device: CustomerDevice,
-) -> None:
-    """Test prepare_set_value is not implemented for all types."""
-    type_information = type_information_type.find_dpcode(mock_device, dpcode)
-
-    assert type_information
-    with pytest.raises(NotImplementedError):
-        type_information.prepare_set_value(mock_device, "any_value")

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -15,6 +15,7 @@ from tuya_device_handlers.type_information import (
     EnumTypeInformation,
     IntegerTypeInformation,
     JsonTypeInformation,
+    PrepareSetValueError,
     RawTypeInformation,
     StringTypeInformation,
     TypeInformation,
@@ -171,3 +172,99 @@ def test_log_invalid_value(
     caplog.clear()
     assert type_information.read_device_value(mock_device) is None
     assert warning_diplayed not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("type_information_type", "dpcode", "value", "expected"),
+    [
+        (BooleanTypeInformation, "demo_boolean", True, True),
+        (BooleanTypeInformation, "demo_boolean", False, False),
+        (EnumTypeInformation, "demo_enum", "scene", "scene"),
+        (EnumTypeInformation, "demo_enum", "colour", "colour"),
+        # Integer scale is 1, so the raw value is the input scaled by 10
+        (IntegerTypeInformation, "demo_integer", 0, 0),
+        (IntegerTypeInformation, "demo_integer", 50, 500),
+        (IntegerTypeInformation, "demo_integer", 100, 1000),
+        (IntegerTypeInformation, "demo_integer", 12.3, 123),
+    ],
+)
+def test_prepare_set_value(
+    type_information_type: type[TypeInformation[Any]],
+    dpcode: str,
+    value: Any,
+    expected: Any,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test prepare_set_value converts a value to its raw form."""
+    type_information = type_information_type.find_dpcode(mock_device, dpcode)
+
+    assert type_information
+    assert type_information.prepare_set_value(mock_device, value) == expected
+
+
+@pytest.mark.parametrize(
+    ("type_information_type", "dpcode", "value", "match"),
+    [
+        (
+            BooleanTypeInformation,
+            "demo_boolean",
+            "yes",
+            "Invalid boolean value `yes`",
+        ),
+        (
+            EnumTypeInformation,
+            "demo_enum",
+            "unknown",
+            "Enum value `unknown` out of range",
+        ),
+        # Scaled raw value above max (1000)
+        (
+            IntegerTypeInformation,
+            "demo_integer",
+            200,
+            "out of range",
+        ),
+        # Scaled raw value below min (0)
+        (
+            IntegerTypeInformation,
+            "demo_integer",
+            -1,
+            "out of range",
+        ),
+    ],
+)
+def test_prepare_set_value_out_of_range(
+    type_information_type: type[TypeInformation[Any]],
+    dpcode: str,
+    value: Any,
+    match: str,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test prepare_set_value rejects invalid values."""
+    type_information = type_information_type.find_dpcode(mock_device, dpcode)
+
+    assert type_information
+    with pytest.raises(PrepareSetValueError, match=match):
+        type_information.prepare_set_value(mock_device, value)
+
+
+@pytest.mark.parametrize(
+    ("type_information_type", "dpcode"),
+    [
+        (BitmapTypeInformation, "demo_bitmap"),
+        (JsonTypeInformation, "demo_json"),
+        (RawTypeInformation, "demo_raw"),
+        (StringTypeInformation, "demo_string"),
+    ],
+)
+def test_prepare_set_value_not_implemented(
+    type_information_type: type[TypeInformation[Any]],
+    dpcode: str,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test prepare_set_value is not implemented for all types."""
+    type_information = type_information_type.find_dpcode(mock_device, dpcode)
+
+    assert type_information
+    with pytest.raises(NotImplementedError):
+        type_information.prepare_set_value(mock_device, "any_value")

--- a/tests/test_type_information.py
+++ b/tests/test_type_information.py
@@ -209,13 +209,25 @@ def test_prepare_set_value(
             BooleanTypeInformation,
             "demo_boolean",
             "yes",
-            "Invalid boolean value `yes`",
+            r"Invalid boolean value `yes` \(str\)",
+        ),
+        (
+            EnumTypeInformation,
+            "demo_enum",
+            True,
+            r"Invalid string value `True` \(bool\)",
         ),
         (
             EnumTypeInformation,
             "demo_enum",
             "unknown",
             "Enum value `unknown` out of range",
+        ),
+        (
+            IntegerTypeInformation,
+            "demo_integer",
+            "145.2",
+            r"Invalid numeric value `145.2` \(str\)",
         ),
         # Scaled raw value above max (1000)
         (


### PR DESCRIPTION
## Summary

Adds `TypeInformation.prepare_set_value(device, value)` as the write-direction counterpart to `read_device_value`, and centralises the set-value conversion that was previously duplicated across DPCode wrappers.

- New `prepare_set_value` on `TypeInformation`, with overrides on `BooleanTypeInformation`, `EnumTypeInformation` and `IntegerTypeInformation`. The validation logic now sits next to the matching `read_device_value`.
- `DPCodeTypeInformationWrapper._convert_value_to_raw_value` delegates to `prepare_set_value`, so `DPCodeBooleanWrapper`, `DPCodeEnumWrapper` and `DPCodeIntegerWrapper` no longer need their own overrides.
- `prepare_set_value` raises a new `type_information.PrepareSetValueError`; the wrapper catches it and re-raises `SetValueOutOfRangeError`, keeping `device_wrapper`'s exception type as the public contract and removing `type_information`'s dependency on `device_wrapper`.

The base `prepare_set_value` raises `NotImplementedError`, so wrappers whose type info doesn't override it (Bitmap/Json/Raw/String) behave exactly as before.

## Test plan

- [x] `poetry run pytest tests` — 340 passed
- [x] `poetry run ty check src`
- [x] `poetry run ruff check` / `ruff format --check`

