### PR TITLE
Add quirk for Anko LD-K3068 smart kettle (dft4ebatvon3ha5s)

### DIFF
--- a/src/tuya_device_handlers/devices/bh/__init__.py
+++ b/src/tuya_device_handlers/devices/bh/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for Tuya BH (smart kettle) devices."""

--- a/src/tuya_device_handlers/devices/bh/__init__.py
+++ b/src/tuya_device_handlers/devices/bh/__init__.py
@@ -1,1 +1,1 @@
-"""Quirks for Tuya BH (smart kettle) devices."""
+"""Quirks for Tuya BH category (smart kettle)."""

--- a/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
+++ b/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
@@ -14,7 +14,12 @@ from tuya_device_handlers.const import DPMode
 
 (
     DeviceQuirk()
-    .applies_to(product_id="dft4ebatvon3ha5s")
+    .applies_to(
+        product_id="dft4ebatvon3ha5s",
+        manufacturer="Anko",
+        model="Smart kettle",
+        model_id="LD-K3068",
+    )
     .add_dpid_enum(
         dpid=4,
         dpcode="temp_setting_quick_c",

--- a/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
+++ b/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
@@ -1,0 +1,27 @@
+"""Quirk for Tuya smart kettle product dft4ebatvon3ha5s.
+
+The Tuya cloud product catalog declares only ["85","90"] for
+temp_setting_quick_c (dpid 4), but the device physically supports
+["80","85","90","95","100"]. This was confirmed via:
+- physical button testing (all 5 values lit the correct button and started heating)
+- local LAN (tinytuya) commands accepted and echoed by device firmware
+- cloud MQTT push reports all 5 values when set physically
+
+See https://github.com/home-assistant/core/issues/XXXXX
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="dft4ebatvon3ha5s")
+    .add_dpid_enum(
+        dpid=4,
+        dpcode="temp_setting_quick_c",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["80", "85", "90", "95", "100"],
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
+++ b/src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py
@@ -3,11 +3,9 @@
 The Tuya cloud product catalog declares only ["85","90"] for
 temp_setting_quick_c (dpid 4), but the device physically supports
 ["80","85","90","95","100"]. This was confirmed via:
-- physical button testing (all 5 values lit the correct button and started heating)
-- local LAN (tinytuya) commands accepted and echoed by device firmware
-- cloud MQTT push reports all 5 values when set physically
-
-See https://github.com/home-assistant/core/issues/XXXXX
+- physical button testing (all values lit and started heating)
+- local LAN (tinytuya) commands accepted and echoed by firmware
+- cloud MQTT push reports all values when set physically
 """
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY

--- a/tests/devices/bh/__init__.py
+++ b/tests/devices/bh/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya BH category (smart kettle) quirks."""

--- a/tests/devices/bh/test_dft4ebatvon3ha5s.py
+++ b/tests/devices/bh/test_dft4ebatvon3ha5s.py
@@ -1,0 +1,35 @@
+"""Test device-level quirk initialisation for BH devices."""
+
+import json
+
+from tests import create_device
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_kettle_expands_temp_setting_quick_c_range(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Test dft4ebatvon3ha5s expands temp_setting_quick_c enum range."""
+    device = create_device("bh_dft4ebatvon3ha5s.json")
+
+    assert json.loads(device.status_range["temp_setting_quick_c"].values) == {
+        "range": ["85", "90"]
+    }
+    assert json.loads(device.function["temp_setting_quick_c"].values) == {
+        "range": ["85", "90"]
+    }
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    expected = {"range": ["80", "85", "90", "95", "100"]}
+    assert (
+        json.loads(device.status_range["temp_setting_quick_c"].values)
+        == expected
+    )
+    assert (
+        json.loads(device.function["temp_setting_quick_c"].values) == expected
+    )
+    assert (
+        json.loads(device.local_strategy[4]["config_item"]["valueDesc"])
+        == expected
+    )

--- a/tests/fixtures/devices/bh_dft4ebatvon3ha5s.json
+++ b/tests/fixtures/devices/bh_dft4ebatvon3ha5s.json
@@ -1,0 +1,145 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Smart kettle",
+  "category": "bh",
+  "product_id": "dft4ebatvon3ha5s",
+  "product_name": "Smart kettle",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2026-05-17T01:54:22+00:00",
+  "create_time": "2026-05-17T01:54:22+00:00",
+  "update_time": "2026-05-17T01:54:22+00:00",
+  "function": {
+    "start": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "temp_setting_quick_c": {
+      "type": "Enum",
+      "value": "{\"range\":[\"85\",\"90\"]}"
+    },
+    "warm": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "work_type": {
+      "type": "Enum",
+      "value": "{\"range\":[\"setting_quick\",\"boiling_quick\",\"temp_setting\",\"temp_boiling\"]}"
+    }
+  },
+  "status_range": {
+    "start": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "temp_setting_quick_c": {
+      "type": "Enum",
+      "value": "{\"range\":[\"85\",\"90\"]}",
+      "report_type": null
+    },
+    "warm": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "status": {
+      "type": "Enum",
+      "value": "{\"range\":[\"standby\",\"heating\",\"cooling\",\"warm\",\"heating_temp\"]}",
+      "report_type": null
+    },
+    "work_type": {
+      "type": "Enum",
+      "value": "{\"range\":[\"setting_quick\",\"boiling_quick\",\"temp_setting\",\"temp_boiling\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "start": false,
+    "temp_current": 0,
+    "temp_setting_quick_c": "90",
+    "warm": false,
+    "status": "standby",
+    "work_type": "setting_quick"
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "start",
+      "config_item": {
+        "statusFormat": "{\"start\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"℃\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "temp_setting_quick_c",
+      "config_item": {
+        "statusFormat": "{\"temp_setting_quick_c\":\"$\"}",
+        "valueDesc": "{\"range\":[\"85\",\"90\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    },
+    "13": {
+      "value_convert": "default",
+      "status_code": "warm",
+      "config_item": {
+        "statusFormat": "{\"warm\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    },
+    "15": {
+      "value_convert": "default",
+      "status_code": "status",
+      "config_item": {
+        "statusFormat": "{\"status\":\"$\"}",
+        "valueDesc": "{\"range\":[\"standby\",\"heating\",\"cooling\",\"warm\",\"heating_temp\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "work_type",
+      "config_item": {
+        "statusFormat": "{\"work_type\":\"$\"}",
+        "valueDesc": "{\"range\":[\"setting_quick\",\"boiling_quick\",\"temp_setting\",\"temp_boiling\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "dft4ebatvon3ha5s"
+      }
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

The Tuya cloud product catalog for product `dft4ebatvon3ha5s` (Anko LD-K3068 smart kettle, K-Mart house brand, category `bh`) declares `temp_setting_quick_c` (dpid 4) with range `["85","90"]`. The device physically supports all five values `["80","85","90","95","100"]`.

This PR adds a quirk that corrects the enum range so Home Assistant can display the actual device state and send all valid commands. Manufacturer / model / model_id are populated from the retail packaging so the device shows up identifiably in the HA device registry.

## What's included

- `src/tuya_device_handlers/devices/bh/dft4ebatvon3ha5s.py` — quirk: expands `temp_setting_quick_c` enum range; sets `manufacturer="Anko"`, `model="Smart kettle"`, `model_id="LD-K3068"`
- `src/tuya_device_handlers/devices/bh/__init__.py` — new BH category package
- `tests/fixtures/devices/bh_dft4ebatvon3ha5s.json` — pre-quirk diagnostics fixture (sanitised)
- `tests/devices/bh/test_dft4ebatvon3ha5s.py` — verifies the quirk expands the range across `function`, `status_range`, and `local_strategy`

## Test plan

Tested on a live device (`product_id: dft4ebatvon3ha5s`):

- **Physical buttons**: all 5 temperature buttons (80/85/90/95/100) lit correctly and started heating — confirmed by physical observation
- **Local LAN** (tinytuya): all 5 values accepted and echoed back by device firmware
- **Cloud MQTT**: device pushes all 5 values as state when set physically
- **Cloud API via official Tuya iOS app** (mobile data, WiFi off): setting 80 succeeded — the cloud accepts the full range; the `["85","90"]` restriction is enforced only on the HA customer API endpoint catalog, not by the cloud itself

## Related issue

None.