### PR TITLE
fix: change default cover position_wrapper to DPCodePercentageWrapper

### DIFF
--- a/src/tuya_device_handlers/definition/cover.py
+++ b/src/tuya_device_handlers/definition/cover.py
@@ -16,6 +16,7 @@ from tuya_device_handlers.device_wrapper.cover import (
 )
 from tuya_device_handlers.device_wrapper.extended import (
     DPCodeInvertedPercentageWrapper,
+    DPCodePercentageWrapper,
 )
 from tuya_device_handlers.helpers.homeassistant import TuyaCoverAction
 
@@ -58,7 +59,7 @@ def get_default_definition(
     ] = CoverInstructionEnumWrapper,
     position_wrapper: type[
         DPCodeTypeInformationWrapper
-    ] = DPCodeInvertedPercentageWrapper,
+    ] = DPCodePercentageWrapper,
 ) -> CoverDefinition | None:
     """Get the default cover definition for a device."""
     if not (

--- a/tests/definition/test_cover.py
+++ b/tests/definition/test_cover.py
@@ -8,6 +8,7 @@ from tuya_device_handlers.device_wrapper.cover import (
 )
 from tuya_device_handlers.device_wrapper.extended import (
     DPCodeInvertedPercentageWrapper,
+    DPCodePercentageWrapper,
 )
 
 
@@ -37,6 +38,26 @@ def test_get_default_definition() -> None:
         definition.set_position_wrapper, DPCodeInvertedPercentageWrapper
     )
     assert not definition.tilt_position_wrapper
+
+
+def test_get_default_definition_default_wrapper_is_non_inverted() -> None:
+    """Test that the default position_wrapper is DPCodePercentageWrapper.
+
+    Devices reporting position in the standard HA convention (0=closed, 100=open)
+    must not have their values inverted. Callers that need inversion must pass
+    position_wrapper=DPCodeInvertedPercentageWrapper explicitly.
+    """
+    device = create_device("cl_zah67ekd.json")
+    definition = get_default_definition(
+        device,
+        current_position_dpcode=("percent_state", "percent_control"),
+        current_state_dpcode=("situation_set", "control"),
+        instruction_dpcode="control",
+        set_position_dpcode="percent_control",
+    )
+    assert definition is not None
+    assert type(definition.current_position_wrapper) is DPCodePercentageWrapper
+    assert type(definition.set_position_wrapper) is DPCodePercentageWrapper
 
 
 def test_get_default_definition_fails() -> None:


### PR DESCRIPTION
## Summary

Changes the default `position_wrapper` in `get_default_definition` from `DPCodeInvertedPercentageWrapper` to `DPCodePercentageWrapper`.

## Root cause

`DPCodeInvertedPercentageWrapper` flips all position values (0→100, 100→0). This is correct only for Tuya devices that report position in the inverted convention (0=open, 100=closed). Devices using the standard HA convention (0=closed, 100=open) had their positions silently reversed, showing open when closed and vice versa, with open/close commands acting in reverse.

The inversion was made the default without a mechanism for callers using standard-convention devices to opt out. This caused a long-standing bug reported across many device models.

## Fix

Change the default to `DPCodePercentageWrapper` (no inversion, matching HA convention). Callers whose devices use the Tuya-inverted convention must now pass `position_wrapper=DPCodeInvertedPercentageWrapper` explicitly — which is already the case for the affected Home Assistant integration entity descriptions.

## Breaking change

Any caller that relied on the inverted default without passing an explicit `position_wrapper` will now receive non-inverted positions. In practice, the only known affected caller is `homeassistant/components/tuya/cover.py` in HA core, which is updated in the companion PR.

## Related

- Home Assistant issue: https://github.com/home-assistant/core/issues/159800
- Companion HA core PR: (filed separately against `home-assistant/core`)

## Test plan

- [x] `test_get_default_definition` — unchanged, passes explicit `position_wrapper=DPCodeInvertedPercentageWrapper`, still passes
- [x] `test_get_default_definition_default_wrapper_is_non_inverted` — new test confirming default is `DPCodePercentageWrapper`
- [x] `test_get_default_definition_fails` — unchanged, passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)