### PR TITLE
feat: add invert_cover_position() to DeviceQuirk

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -99,6 +99,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
         """Initialize the quirk."""
         self._applies_to: str | None = None
         self._override_category: str | None = None
+        self._cover_position_inverted: bool | None = None
 
         self._datapoint_definitions = {}
         self._local_strategy = {}
@@ -127,11 +128,16 @@ class DeviceQuirk(DeviceQuirkProtocol):
         """Initialise device."""
         self.original_category = device.category
         self.original_function = device.function.copy()
-        self.original_local_strategy = device.local_strategy.copy()
+        self.original_local_strategy = (
+            device.local_strategy.copy() if device.local_strategy is not None else None
+        )
         self.original_status_range = device.status_range.copy()
 
         if self._override_category is not None:
             device.category = self._override_category
+
+        if self._cover_position_inverted is not None:
+            device.quirk_cover_position_inverted = self._cover_position_inverted  # type: ignore[attr-defined]
 
         for key, definition in self._datapoint_definitions.items():
             dpid, dpcode = key
@@ -307,6 +313,18 @@ class DeviceQuirk(DeviceQuirkProtocol):
     def remove_dpid_strategy(self, *, dpid: int, dpcode: str) -> Self:
         """Remove datapoint strategy."""
         self._local_strategy[(dpid, dpcode)] = None
+        return self
+
+    def invert_cover_position(self, *, inverted: bool = True) -> Self:
+        """Override whether cover position values are inverted for this device.
+
+        By default the CL cover mapping uses DPCodeInvertedPercentageWrapper
+        because most Tuya curtain/blind motors report 0=open, 100=closed.
+        Call this with ``inverted=False`` for devices that report position in
+        the standard HA convention (0=closed, 100=open) and must not be
+        inverted.
+        """
+        self._cover_position_inverted = inverted
         return self
 
     def map_feeder_schedules_wrapper(

--- a/src/tuya_device_handlers/definition/cover.py
+++ b/src/tuya_device_handlers/definition/cover.py
@@ -16,6 +16,7 @@ from tuya_device_handlers.device_wrapper.cover import (
 )
 from tuya_device_handlers.device_wrapper.extended import (
     DPCodeInvertedPercentageWrapper,
+    DPCodePercentageWrapper,
 )
 from tuya_device_handlers.helpers.homeassistant import TuyaCoverAction
 
@@ -61,6 +62,11 @@ def get_default_definition(
     ] = DPCodeInvertedPercentageWrapper,
 ) -> CoverDefinition | None:
     """Get the default cover definition for a device."""
+    # A per-device quirk may override position inversion via
+    # DeviceQuirk.invert_cover_position(). Honour it over the caller default.
+    if (inverted := getattr(device, "quirk_cover_position_inverted", None)) is not None:
+        position_wrapper = DPCodeInvertedPercentageWrapper if inverted else DPCodePercentageWrapper
+
     if not (
         instruction_dpcode in device.function
         or instruction_dpcode in device.status_range

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -381,3 +381,40 @@ def test_register_without_applies_to_raises() -> None:
         ValueError, match="does not have an applies_to condition"
     ):
         quirk.register(QuirksRegistry())
+
+
+def test_invert_cover_position_stores_flag() -> None:
+    """invert_cover_position stores the inverted flag on the quirk."""
+    quirk = DeviceQuirk().invert_cover_position(inverted=False)
+    assert quirk._cover_position_inverted is False
+
+    quirk_inverted = DeviceQuirk().invert_cover_position(inverted=True)
+    assert quirk_inverted._cover_position_inverted is True
+
+    quirk_default = DeviceQuirk().invert_cover_position()
+    assert quirk_default._cover_position_inverted is True
+
+
+def test_invert_cover_position_sets_attribute_on_device(
+    mock_device: CustomerDevice,
+) -> None:
+    """initialise_device sets quirk_cover_position_inverted on the device."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+
+    DeviceQuirk().invert_cover_position(inverted=False).initialise_device(mock_device)
+    assert getattr(mock_device, "quirk_cover_position_inverted") is False
+
+    DeviceQuirk().invert_cover_position(inverted=True).initialise_device(mock_device)
+    assert getattr(mock_device, "quirk_cover_position_inverted") is True
+
+
+def test_invert_cover_position_not_set_leaves_device_unchanged(
+    mock_device: CustomerDevice,
+) -> None:
+    """Without invert_cover_position, the device attribute is not set."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+
+    DeviceQuirk().initialise_device(mock_device)
+    assert not hasattr(mock_device, "quirk_cover_position_inverted")


### PR DESCRIPTION
## Summary

- Adds `DeviceQuirk.invert_cover_position(inverted=True/False)` — a chainable builder method that lets a per-device quirk override cover position inversion
- `initialise_device()` propagates the flag to `device.quirk_cover_position_inverted`
- `get_default_definition()` in `definition/cover.py` honours the flag when present, falling back to the caller-supplied `position_wrapper` otherwise (default remains `DPCodeInvertedPercentageWrapper`)
- Tests added to `tests/builder/test_device_quirk.py`

The per-device zah67ekd quirk that uses this is in a separate PR, as requested in [#226](https://github.com/home-assistant-libs/tuya-device-handlers/pull/226#issuecomment-4542089347).

> **Note:** This PR was split from #226 following review feedback. The approach may change depending on the outcome of the discussion about using #201 — happy to rework if the TypeInformation override path turns out to be a better fit.

## Test plan

- [x] `python -m pytest tests/builder/test_device_quirk.py` — 28 passed