### PR TITLE
Ensure device wrapper reads and prepares values via TypeInformation

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/binary_sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/binary_sensor.py
@@ -61,6 +61,6 @@ class DPCodeInSetWrapper(DPCodeWrapper[bool]):
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:
         """Read the device value for the dpcode."""
-        if (raw_value := device.status.get(self.dpcode)) is None:
+        if (raw_value := self._read_dpcode_value(device)) is None:
             return None
         return raw_value in self._valid_values

--- a/src/tuya_device_handlers/device_wrapper/extended.py
+++ b/src/tuya_device_handlers/device_wrapper/extended.py
@@ -45,7 +45,7 @@ class DPCodeRemappedIntegerWrapper(DPCodeIntegerWrapper[int]):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Read and round the device status."""
-        if (value := device.status.get(self.dpcode)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
 
         return round(
@@ -57,10 +57,11 @@ class DPCodeRemappedIntegerWrapper(DPCodeIntegerWrapper[int]):
     def _convert_value_to_raw_value(
         self, device: CustomerDevice, value: Any
     ) -> int:
-        return round(
+        return super()._convert_value_to_raw_value(
+            device,
             self._remap_helper.remap_value_from(
                 value, reverse=self._remap_inverted(device)
-            )
+            ),
         )
 
 

--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -36,7 +36,7 @@ class BrightnessWrapper(DPCodeIntegerWrapper[int]):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Return the brightness of this light between 0..255."""
-        if (brightness := device.status.get(self.dpcode)) is None:
+        if (brightness := self._read_dpcode_value(device)) is None:
             return None
 
         # Remap value to our scale
@@ -50,11 +50,17 @@ class BrightnessWrapper(DPCodeIntegerWrapper[int]):
             and self.brightness_max_remap is not None
             and self.brightness_min_remap is not None
             and (
-                brightness_max := device.status.get(self.brightness_max.dpcode)
+                brightness_max
+                := self.brightness_max.type_information.read_device_value(
+                    device
+                )
             )
             is not None
             and (
-                brightness_min := device.status.get(self.brightness_min.dpcode)
+                brightness_min
+                := self.brightness_min.type_information.read_device_value(
+                    device
+                )
             )
             is not None
         ):
@@ -89,11 +95,17 @@ class BrightnessWrapper(DPCodeIntegerWrapper[int]):
             and self.brightness_max_remap is not None
             and self.brightness_min_remap is not None
             and (
-                brightness_max := device.status.get(self.brightness_max.dpcode)
+                brightness_max
+                := self.brightness_max.type_information.read_device_value(
+                    device
+                )
             )
             is not None
             and (
-                brightness_min := device.status.get(self.brightness_min.dpcode)
+                brightness_min
+                := self.brightness_min.type_information.read_device_value(
+                    device
+                )
             )
             is not None
         ):
@@ -113,7 +125,9 @@ class BrightnessWrapper(DPCodeIntegerWrapper[int]):
                 to_min=brightness_min,
                 to_max=brightness_max,
             )
-        return round(self._remap_helper.remap_value_from(value))
+        return super()._convert_value_to_raw_value(
+            device, self._remap_helper.remap_value_from(value)
+        )
 
 
 class ColorTempWrapper(DPCodeIntegerWrapper[int]):
@@ -150,7 +164,7 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Return the color temperature value in Kelvin."""
-        if (temperature := device.status.get(self.dpcode)) is None:
+        if (temperature := self._read_dpcode_value(device)) is None:
             return None
 
         return self.mired_to_kelvin(
@@ -161,11 +175,12 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
         self, device: CustomerDevice, value: int
     ) -> Any:
         """Convert HA value (Kelvin) to a raw device value."""
-        return round(
+        return super()._convert_value_to_raw_value(
+            device,
             self._remap_helper.remap_value_from(
                 self.kelvin_to_mired(value),
                 reverse=True,
-            )
+            ),
         )
 
 

--- a/src/tuya_device_handlers/utils.py
+++ b/src/tuya_device_handlers/utils.py
@@ -10,8 +10,8 @@ from .type_information import IntegerTypeInformation
 class RemapHelper:
     """Helper class for remapping values."""
 
-    source_min: int
-    source_max: int
+    source_min: float
+    source_max: float
     target_min: float
     target_max: float
 
@@ -22,10 +22,15 @@ class RemapHelper:
         target_min: float,
         target_max: float,
     ) -> Self:
-        """Create RemapHelper from IntegerTypeInformation."""
+        """Create RemapHelper from IntegerTypeInformation.
+
+        The source range uses the scaled min/max so that callers can feed
+        values straight from `TypeInformation.read_device_value` /
+        `_read_dpcode_value` (both of which return scaled values).
+        """
         return cls(
-            source_min=type_information.min,
-            source_max=type_information.max,
+            source_min=type_information.scale_value(type_information.min),
+            source_max=type_information.scale_value(type_information.max),
             target_min=target_min,
             target_max=target_max,
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,17 +21,22 @@ def test_remap_helper() -> None:
 def test_remap_helper_from_type_information(
     mock_device: CustomerDevice,
 ) -> None:
-    """Test RemapHelper from TypeInformation."""
+    """Test RemapHelper from TypeInformation.
+
+    `demo_integer` has min=0, max=1000, scale=1 — so the helper's
+    source range is the *scaled* range (0..100), matching the values
+    returned by `TypeInformation.read_device_value`.
+    """
     type_information = IntegerTypeInformation.find_dpcode(
         mock_device, "demo_integer"
     )
     assert type_information
     remap_helper = RemapHelper.from_type_information(type_information, 0, 255)
 
-    assert round(remap_helper.remap_value_from(100)) == 392
-    assert round(remap_helper.remap_value_to(392)) == 100
-    assert round(remap_helper.remap_value_from(100, reverse=True)) == 608
-    assert round(remap_helper.remap_value_to(608, reverse=True)) == 100
+    assert round(remap_helper.remap_value_from(100), 1) == 39.2
+    assert round(remap_helper.remap_value_to(39.2), 1) == 100
+    assert round(remap_helper.remap_value_from(100, reverse=True), 1) == 60.8
+    assert round(remap_helper.remap_value_to(60.8, reverse=True), 1) == 100
 
 
 def test_remap_helper_from_function_data() -> None:


### PR DESCRIPTION
## Summary

- Device wrappers now read their DPCode via `_read_dpcode_value` (and `TypeInformation.read_device_value` for cross-wrapper reads) instead of reaching into `device.status.get(self.dpcode)` directly. This restores the validation + scaling that `TypeInformation.read_device_value` provides — previously bypassed in `BrightnessWrapper`, `ColorTempWrapper`, `DPCodeRemappedIntegerWrapper`, and `DPCodeInSetWrapper`.
- Write-side counterparts (`_convert_value_to_raw_value`) delegate to `super()._convert_value_to_raw_value` so scale-back and range validation flow through `TypeInformation.prepare_set_value` instead of open-coded `round(...)`.
- `RemapHelper.from_type_information` now uses the **scaled** source range (`scale_value(min)..scale_value(max)`) so it lines up with the scaled values returned by `_read_dpcode_value` / `read_device_value`. Source fields retyped to `float`. This resolves an existing inconsistency where `DPCodeIntegerWrapper.min_value`/`max_value` were already scaled but the helper's source range was raw.

## Behavior

Mathematically equivalent for the common `scale=0` case (all existing brightness / color-temp / extended tests pass unchanged). For non-zero scales, behavior is now consistent with the rest of the integer pipeline: values are validated against the declared raw `min`/`max` on both read and write, and out-of-range reads emit the standard `_should_log_warning` warning instead of being silently passed through.

## Test plan

- [x] `poetry run pytest --cov tuya_device_handlers tests` — 354 passed
- [x] `poetry run ty check src tests` — clean
- [x] `poetry run pylint src/tuya_device_handlers` — 10.00/10
- [x] `poetry run ruff check .` / `ruff format --check .` — clean on changed files
- [x] Updated `test_remap_helper_from_type_information` to reflect the new scaled-source semantics on `demo_integer` (scale=1)
