### PR TITLE
tests: add DPCodeInvertedPercentageWrapper full-chain tests

### DIFF
--- a/tests/definition/test_cover.py
+++ b/tests/definition/test_cover.py
@@ -127,3 +127,58 @@ def test_cover_position_quirk_type_information_override(
     assert position_wrapper.get_update_commands(device, 70) == [
         {"code": "percent_state", "value": expected_raw_write}
     ]
+
+
+@pytest.mark.parametrize("fixture_file", ["cl_68nvbio9.json", "cl_cf1sl3tj.json"])
+@pytest.mark.parametrize(
+    (
+        "type_information_cls_override",
+        "expected_position",
+        "expected_raw_write",
+    ),
+    [
+        # Without override: wrapper inverts raw 52 → 48 (the bug for devices
+        # that already report position in HA convention, 0=closed/100=open).
+        (IntegerTypeInformation, 48, 30),
+        # With inverted TypeInformation: TypeInfo pre-inverts 52→48, wrapper
+        # re-inverts 48→52. Double inversion cancels → correct HA position.
+        (_InvertedPercentageIntegerTypeInformation, 52, 70),
+    ],
+)
+def test_cover_inverted_percentage_wrapper_type_information_override(
+    fixture_file: str,
+    type_information_cls_override: type[IntegerTypeInformation],
+    expected_position: int,
+    expected_raw_write: int,
+) -> None:
+    """TypeInformation override cancels DPCodeInvertedPercentageWrapper inversion."""
+    device = create_device(fixture_file)
+    (
+        DeviceQuirk()
+        .applies_to(product_id=device.product_id)
+        .override_dpid_type_information_cls(
+            dpid=3,
+            dpcode="percent_state",
+            type_information_cls=type_information_cls_override,
+        )
+        .register(TUYA_QUIRKS_REGISTRY)
+    )
+
+    definition = get_default_definition(
+        device,
+        current_position_dpcode=("percent_state", "percent_control"),
+        instruction_dpcode="control",
+        set_position_dpcode="percent_control",
+        position_wrapper=DPCodeInvertedPercentageWrapper,
+    )
+    assert definition is not None
+    position_wrapper = definition.current_position_wrapper
+    assert isinstance(position_wrapper, DPCodeInvertedPercentageWrapper)
+    assert position_wrapper.dpcode == "percent_state"
+    assert isinstance(
+        position_wrapper.type_information, type_information_cls_override
+    )
+    assert position_wrapper.read_device_status(device) == expected_position
+    assert position_wrapper.get_update_commands(device, 70) == [
+        {"code": "percent_state", "value": expected_raw_write}
+    ]

--- a/tests/definition/test_cover.py
+++ b/tests/definition/test_cover.py
@@ -129,7 +129,9 @@ def test_cover_position_quirk_type_information_override(
     ]
 
 
-@pytest.mark.parametrize("fixture_file", ["cl_68nvbio9.json", "cl_cf1sl3tj.json"])
+@pytest.mark.parametrize(
+    "fixture_file", ["cl_68nvbio9.json", "cl_cf1sl3tj.json"]
+)
 @pytest.mark.parametrize(
     (
         "type_information_cls_override",
@@ -151,7 +153,7 @@ def test_cover_inverted_percentage_wrapper_type_information_override(
     expected_position: int,
     expected_raw_write: int,
 ) -> None:
-    """TypeInformation override cancels DPCodeInvertedPercentageWrapper inversion."""
+    """TypeInformation override cancels the cover wrapper's inversion."""
     device = create_device(fixture_file)
     (
         DeviceQuirk()

--- a/tests/fixtures/devices/cl_68nvbio9.json
+++ b/tests/fixtures/devices/cl_68nvbio9.json
@@ -1,0 +1,60 @@
+{
+  "name": "Blinds",
+  "category": "cl",
+  "product_id": "68nvbio9",
+  "product_name": "",
+  "online": true,
+  "function": {
+    "control": {
+      "type": "Enum",
+      "value": { "range": ["open", "stop", "close", "continue"] }
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": { "range": ["forward", "back"] }
+    }
+  },
+  "status_range": {
+    "control": {
+      "type": "Enum",
+      "value": { "range": ["open", "stop", "close", "continue"] }
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": { "range": ["forward", "back"] }
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": { "range": ["opening", "closing"] }
+    },
+    "situation_set": {
+      "type": "Enum",
+      "value": { "range": ["fully_open", "fully_close"] }
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": { "label": ["motor_fault"] }
+    }
+  },
+  "status": {
+    "control": "stop",
+    "percent_control": 100,
+    "percent_state": 52,
+    "control_back_mode": "forward",
+    "work_state": "closing",
+    "situation_set": "fully_open",
+    "fault": 0
+  }
+}

--- a/tests/fixtures/devices/cl_cf1sl3tj.json
+++ b/tests/fixtures/devices/cl_cf1sl3tj.json
@@ -1,0 +1,60 @@
+{
+  "name": "Curtains",
+  "category": "cl",
+  "product_id": "cf1sl3tj",
+  "product_name": "",
+  "online": true,
+  "function": {
+    "control": {
+      "type": "Enum",
+      "value": { "range": ["open", "stop", "close"] }
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": { "range": ["forward", "back"] }
+    }
+  },
+  "status_range": {
+    "control": {
+      "type": "Enum",
+      "value": { "range": ["open", "stop", "close"] }
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": { "unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1 }
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": { "range": ["forward", "back"] }
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": { "range": ["opening", "closing"] }
+    },
+    "situation_set": {
+      "type": "Enum",
+      "value": { "range": ["fully_open", "fully_close"] }
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": { "label": ["motor_fault"] }
+    }
+  },
+  "status": {
+    "control": "stop",
+    "percent_control": 100,
+    "percent_state": 52,
+    "control_back_mode": "forward",
+    "work_state": "closing",
+    "situation_set": "fully_open",
+    "fault": 0
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `test_cover_inverted_percentage_wrapper_type_information_override`, a parametrized test demonstrating the cover position inversion bug and its fix through the `TypeInformation` class override mechanism introduced in this PR.
- The test uses `DPCodeInvertedPercentageWrapper` (the actual default cover position wrapper), parametrized over:
  - `IntegerTypeInformation` — shows the bug: raw `percent_state=52` → HA reads 48 (incorrectly inverted).
  - `_InvertedPercentageIntegerTypeInformation` — shows the fix: TypeInfo pre-inverts 52→48, wrapper re-inverts 48→52 (double inversion cancels → correct HA value of 52).
- Adds device fixtures for `cl_68nvbio9` (blinds, `control` range includes `continue`) and `cl_cf1sl3tj` (curtains, standard three-value `control` range) — the real affected devices that motivated this fix, alongside the original reporter's `zah67ekd`.

## Context

The original issue ([#159800](https://github.com/home-assistant/core/issues/159800)) was reported for `zah67ekd`. This fix also addresses `68nvbio9` and `cf1sl3tj` which exhibit the same reversed-position behaviour.

The existing `test_cover_position_quirk_type_information_override` test used `DPCodeIntegerWrapper` as the wrapper; these new tests exercise the complete chain through `DPCodeInvertedPercentageWrapper` to confirm the override flows end-to-end through the remap logic.

Generated with Claude Code