### PR TITLE
Add quirk for curtain motor (cf1sl3tj)

### DIFF
--- a/src/tuya_device_handlers/devices/cl/cl_cf1sl3tj.py
+++ b/src/tuya_device_handlers/devices/cl/cl_cf1sl3tj.py
@@ -1,0 +1,72 @@
+"""Quirk for Tuya curtain motor (product_id cf1sl3tj).
+
+This device reports ``percent_state`` in the standard HA convention
+(0 = closed, 100 = open).  The default CL mapping uses
+``DPCodeInvertedPercentageWrapper`` because most Tuya curtain/blind motors
+report position inverted (0 = open, 100 = closed), which causes the
+position to be displayed and set backwards for this device.
+
+Applying ``_InvertedIntegerTypeInformationEx`` pre-inverts the value at the
+TypeInformation level, so the wrapper's own inversion cancels out and the
+position is reported and set correctly.
+
+See https://github.com/home-assistant/core/issues/159800.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from tuya_sharing import CustomerDevice
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.type_information import IntegerTypeInformation
+
+
+@dataclass(kw_only=True)
+class _InvertedIntegerTypeInformationEx(IntegerTypeInformation):
+    """IntegerTypeInformation that inverts the value within its range.
+
+    Read: returns ``scale_value(max) - value`` instead of ``value``.
+    Write: sends ``max - scale_value_back(value)`` to the device.
+
+    Intended for devices that report a value in the opposite direction to
+    what the default wrapper expects.  For example, if the wrapper inverts
+    a 0-100 percentage and the device already reports in HA convention
+    (0 = closed, 100 = open), applying this class via
+    ``override_dpid_type_information_cls`` pre-inverts at the TypeInformation
+    level so the wrapper's own inversion cancels out, yielding the correct
+    value.
+    """
+
+    def read_device_value(self, device: CustomerDevice) -> float | None:
+        """Read and invert the device value."""
+        value = super().read_device_value(device)
+        if value is None:
+            return None
+        return self.scale_value(self.max) - value
+
+    def prepare_set_value(self, device: CustomerDevice, value: Any) -> int:
+        """Invert and prepare a value to be sent to the device."""
+        if not isinstance(value, (int, float)):
+            return super().prepare_set_value(device, value)
+        return super().prepare_set_value(
+            device, self.scale_value(self.max) - value
+        )
+
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="cf1sl3tj")
+    .override_dpid_type_information_cls(
+        dpid=2,
+        dpcode="percent_control",
+        type_information_cls=_InvertedIntegerTypeInformationEx,
+    )
+    .override_dpid_type_information_cls(
+        dpid=3,
+        dpcode="percent_state",
+        type_information_cls=_InvertedIntegerTypeInformationEx,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/cl/test_cf1sl3tj.py
+++ b/tests/devices/cl/test_cf1sl3tj.py
@@ -24,21 +24,21 @@ from tuya_device_handlers.type_information import (
 def test_quirk_corrects_position(
     filled_quirks_registry: QuirksRegistry,
 ) -> None:
-    """With quirk, percent_state=52 reads as 52 (not inverted to 48)."""
+    """With quirk, percent_state=90 reads as 90 (not inverted to 10)."""
     device = create_device("cl_cf1sl3tj.json")
 
     with patch.dict(TUYA_QUIRKS_REGISTRY._quirks, clear=True):
         definitions = get_cover_default_definitions(device)
     wrapper = definitions["control"].current_position_wrapper
     assert wrapper is not None
-    assert wrapper.read_device_status(device) == 48
+    assert wrapper.read_device_status(device) == 90
 
     filled_quirks_registry.initialise_device_quirk(device)
 
     definitions = get_cover_default_definitions(device)
     wrapper = definitions["control"].current_position_wrapper
     assert wrapper is not None
-    assert wrapper.read_device_status(device) == 52
+    assert wrapper.read_device_status(device) == 10
 
 
 def test_quirk_corrects_position_write(

--- a/tests/devices/cl/test_cf1sl3tj.py
+++ b/tests/devices/cl/test_cf1sl3tj.py
@@ -1,0 +1,95 @@
+"""Tests for the cf1sl3tj cover position quirk.
+
+This device reports percent_state in HA convention (0=closed, 100=open).
+Without the quirk the default DPCodeInvertedPercentageWrapper incorrectly
+inverts position values.
+
+See https://github.com/home-assistant/core/issues/159800.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tests import create_device
+from tests.integration_helpers.cover import get_cover_default_definitions
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.registry import QuirksRegistry
+from tuya_device_handlers.type_information import (
+    IntegerTypeInformation,
+    PrepareSetValueError,
+)
+
+
+def test_quirk_corrects_position(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """With quirk, percent_state=52 reads as 52 (not inverted to 48)."""
+    device = create_device("cl_cf1sl3tj.json")
+
+    with patch.dict(TUYA_QUIRKS_REGISTRY._quirks, clear=True):
+        definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].current_position_wrapper
+    assert wrapper is not None
+    assert wrapper.read_device_status(device) == 48
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].current_position_wrapper
+    assert wrapper is not None
+    assert wrapper.read_device_status(device) == 52
+
+
+def test_quirk_corrects_position_write(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """With quirk, setting position 70 sends raw value 70 (not 30)."""
+    device = create_device("cl_cf1sl3tj.json")
+
+    with patch.dict(TUYA_QUIRKS_REGISTRY._quirks, clear=True):
+        definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].set_position_wrapper
+    assert wrapper is not None
+    assert wrapper.get_update_commands(device, 70) == [
+        {"code": "percent_control", "value": 30}
+    ]
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].set_position_wrapper
+    assert wrapper is not None
+    assert wrapper.get_update_commands(device, 70) == [
+        {"code": "percent_control", "value": 70}
+    ]
+
+
+def test_quirk_read_handles_missing_value(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Read returns None (not inverted) when the device reports no value."""
+    device = create_device("cl_cf1sl3tj.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+    del device.status["percent_state"]
+
+    type_information = IntegerTypeInformation.find_dpcode(
+        device, "percent_state"
+    )
+    assert type_information is not None
+    assert type_information.read_device_value(device) is None
+
+
+def test_quirk_write_delegates_non_numeric(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Write delegates non-numeric values to the parent class for validation."""
+    device = create_device("cl_cf1sl3tj.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    type_information = IntegerTypeInformation.find_dpcode(
+        device, "percent_control"
+    )
+    assert type_information is not None
+    with pytest.raises(PrepareSetValueError):
+        type_information.prepare_set_value(device, "stop")

--- a/tests/fixtures/devices/cl_cf1sl3tj.json
+++ b/tests/fixtures/devices/cl_cf1sl3tj.json
@@ -1,0 +1,247 @@
+{
+  "name": "Blinds",
+  "category": "cl",
+  "product_id": "cf1sl3tj",
+  "product_name": "",
+  "online": true,
+  "function": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}"
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"morning\",\"night\"]}"
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}"
+    },
+    "border": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}"
+    },
+    "position_best": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}"
+    }
+  },
+  "status_range": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}",
+      "report_type": null
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"morning\",\"night\"]}",
+      "report_type": null
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}",
+      "report_type": null
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": "{\"range\":[\"opening\",\"closing\"]}",
+      "report_type": null
+    },
+    "situation_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"fully_open\",\"fully_close\"]}",
+      "report_type": null
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": "{\"label\":[\"motor_fault\"]}",
+      "report_type": null
+    },
+    "battery_percentage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "border": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
+      "report_type": null
+    },
+    "position_best": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "control": "stop",
+    "percent_control": 52,
+    "percent_state": 52,
+    "mode": "morning",
+    "control_back_mode": "forward",
+    "work_state": "opening",
+    "situation_set": "fully_open",
+    "fault": 0,
+    "battery_percentage": 55,
+    "border": "down",
+    "position_best": 0,
+    "click_control": "up"
+  },
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "control",
+      "config_item": {
+        "statusFormat": "{\"control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"open\",\"stop\",\"close\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "percent_control",
+      "config_item": {
+        "statusFormat": "{\"percent_control\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "percent_state",
+      "config_item": {
+        "statusFormat": "{\"percent_state\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"morning\",\"night\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "control_back_mode",
+      "config_item": {
+        "statusFormat": "{\"control_back_mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"forward\",\"back\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "7": {
+      "value_convert": "default",
+      "status_code": "work_state",
+      "config_item": {
+        "statusFormat": "{\"work_state\":\"$\"}",
+        "valueDesc": "{\"range\":[\"opening\",\"closing\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "11": {
+      "value_convert": "default",
+      "status_code": "situation_set",
+      "config_item": {
+        "statusFormat": "{\"situation_set\":\"$\"}",
+        "valueDesc": "{\"range\":[\"fully_open\",\"fully_close\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "12": {
+      "value_convert": "default",
+      "status_code": "fault",
+      "config_item": {
+        "statusFormat": "{\"fault\":\"$\"}",
+        "valueDesc": "{\"label\":[\"motor_fault\"]}",
+        "valueType": "Bitmap",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "13": {
+      "value_convert": "default",
+      "status_code": "battery_percentage",
+      "config_item": {
+        "statusFormat": "{\"battery_percentage\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "border",
+      "config_item": {
+        "statusFormat": "{\"border\":\"$\"}",
+        "valueDesc": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "position_best",
+      "config_item": {
+        "statusFormat": "{\"position_best\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "20": {
+      "value_convert": "default",
+      "status_code": "click_control",
+      "config_item": {
+        "statusFormat": "{\"click_control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"up\",\"down\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    }
+  }
+}

--- a/tests/fixtures/devices/cl_cf1sl3tj.json
+++ b/tests/fixtures/devices/cl_cf1sl3tj.json
@@ -1,9 +1,18 @@
 {
-  "name": "Blinds",
+  "endpoint": "**REDACTED**",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Living Room Left Curtains",
   "category": "cl",
   "product_id": "cf1sl3tj",
   "product_name": "",
-  "online": true,
+  "online": false,
+  "sub": true,
+  "time_zone": "+00:00",
+  "active_time": "2026-03-02T18:14:11+00:00",
+  "create_time": "2026-03-02T18:14:11+00:00",
+  "update_time": "2026-03-02T18:14:11+00:00",
   "function": {
     "control": {
       "type": "Enum",
@@ -33,82 +42,6 @@
       "type": "Enum",
       "value": "{\"range\":[\"up\",\"down\"]}"
     }
-  },
-  "status_range": {
-    "control": {
-      "type": "Enum",
-      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}",
-      "report_type": null
-    },
-    "percent_control": {
-      "type": "Integer",
-      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "percent_state": {
-      "type": "Integer",
-      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "mode": {
-      "type": "Enum",
-      "value": "{\"range\":[\"morning\",\"night\"]}",
-      "report_type": null
-    },
-    "control_back_mode": {
-      "type": "Enum",
-      "value": "{\"range\":[\"forward\",\"back\"]}",
-      "report_type": null
-    },
-    "work_state": {
-      "type": "Enum",
-      "value": "{\"range\":[\"opening\",\"closing\"]}",
-      "report_type": null
-    },
-    "situation_set": {
-      "type": "Enum",
-      "value": "{\"range\":[\"fully_open\",\"fully_close\"]}",
-      "report_type": null
-    },
-    "fault": {
-      "type": "Bitmap",
-      "value": "{\"label\":[\"motor_fault\"]}",
-      "report_type": null
-    },
-    "battery_percentage": {
-      "type": "Integer",
-      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "border": {
-      "type": "Enum",
-      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
-      "report_type": null
-    },
-    "position_best": {
-      "type": "Integer",
-      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "click_control": {
-      "type": "Enum",
-      "value": "{\"range\":[\"up\",\"down\"]}",
-      "report_type": null
-    }
-  },
-  "status": {
-    "control": "stop",
-    "percent_control": 52,
-    "percent_state": 52,
-    "mode": "morning",
-    "control_back_mode": "forward",
-    "work_state": "opening",
-    "situation_set": "fully_open",
-    "fault": 0,
-    "battery_percentage": 55,
-    "border": "down",
-    "position_best": 0,
-    "click_control": "up"
   },
   "local_strategy": {
     "1": {
@@ -242,6 +175,313 @@
         "enumMappingMap": {},
         "pid": "cf1sl3tj"
       }
+    }
+  },
+  "status_range": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}",
+      "report_type": null
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"morning\",\"night\"]}",
+      "report_type": null
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}",
+      "report_type": null
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": "{\"range\":[\"opening\",\"closing\"]}",
+      "report_type": null
+    },
+    "situation_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"fully_open\",\"fully_close\"]}",
+      "report_type": null
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": "{\"label\":[\"motor_fault\"]}",
+      "report_type": null
+    },
+    "battery_percentage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "border": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
+      "report_type": null
+    },
+    "position_best": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "control": "stop",
+    "percent_control": 10,
+    "percent_state": 10,
+    "mode": "morning",
+    "control_back_mode": "forward",
+    "work_state": "opening",
+    "situation_set": "fully_open",
+    "fault": 0,
+    "battery_percentage": 55,
+    "border": "down",
+    "position_best": 0,
+    "click_control": "up"
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": "/config/tuya_quirks/cl_cf1sl3tj.py:59",
+  "warnings": null,
+  "original_category": "cl",
+  "original_function": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}"
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"morning\",\"night\"]}"
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}"
+    },
+    "border": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}"
+    },
+    "position_best": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}"
+    }
+  },
+  "original_local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "control",
+      "config_item": {
+        "statusFormat": "{\"control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"open\",\"stop\",\"close\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "percent_control",
+      "config_item": {
+        "statusFormat": "{\"percent_control\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "percent_state",
+      "config_item": {
+        "statusFormat": "{\"percent_state\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"morning\",\"night\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "control_back_mode",
+      "config_item": {
+        "statusFormat": "{\"control_back_mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"forward\",\"back\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "7": {
+      "value_convert": "default",
+      "status_code": "work_state",
+      "config_item": {
+        "statusFormat": "{\"work_state\":\"$\"}",
+        "valueDesc": "{\"range\":[\"opening\",\"closing\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "11": {
+      "value_convert": "default",
+      "status_code": "situation_set",
+      "config_item": {
+        "statusFormat": "{\"situation_set\":\"$\"}",
+        "valueDesc": "{\"range\":[\"fully_open\",\"fully_close\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "12": {
+      "value_convert": "default",
+      "status_code": "fault",
+      "config_item": {
+        "statusFormat": "{\"fault\":\"$\"}",
+        "valueDesc": "{\"label\":[\"motor_fault\"]}",
+        "valueType": "Bitmap",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "13": {
+      "value_convert": "default",
+      "status_code": "battery_percentage",
+      "config_item": {
+        "statusFormat": "{\"battery_percentage\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "border",
+      "config_item": {
+        "statusFormat": "{\"border\":\"$\"}",
+        "valueDesc": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "position_best",
+      "config_item": {
+        "statusFormat": "{\"position_best\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    },
+    "20": {
+      "value_convert": "default",
+      "status_code": "click_control",
+      "config_item": {
+        "statusFormat": "{\"click_control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"up\",\"down\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "cf1sl3tj"
+      }
+    }
+  },
+  "original_status_range": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\"]}",
+      "report_type": null
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"morning\",\"night\"]}",
+      "report_type": null
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}",
+      "report_type": null
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": "{\"range\":[\"opening\",\"closing\"]}",
+      "report_type": null
+    },
+    "situation_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"fully_open\",\"fully_close\"]}",
+      "report_type": null
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": "{\"label\":[\"motor_fault\"]}",
+      "report_type": null
+    },
+    "battery_percentage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "border": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
+      "report_type": null
+    },
+    "position_best": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}",
+      "report_type": null
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a per-device quirk for product ID `cf1sl3tj` (Tuya curtain motor) that reports `percent_state` in HA convention (0 = closed, 100 = open), but the default `DPCodeInvertedPercentageWrapper` inverts this, causing incorrect position display and control.

The fix applies `_InvertedIntegerTypeInformationEx` (local copy, same pattern as #226) on `dpid=3`/`percent_state` so the double inversion cancels out and position is reported and set correctly.

**Depends on #226** — please merge after that lands.

Closes https://github.com/home-assistant/core/issues/159800.

## Changes

- `src/tuya_device_handlers/devices/cl/cl_cf1sl3tj.py` — quirk with local `_InvertedIntegerTypeInformationEx`
- `tests/fixtures/devices/cl_cf1sl3tj.json` — device fixture (`percent_state: 52`)
- `tests/devices/cl/test_cl_cf1sl3tj.py` — two tests verifying read and write inversion correction

## Test plan

- [ ] `test_quirk_corrects_position` — without quirk: 52 reads as 48; with quirk: 52 reads as 52
- [ ] `test_quirk_corrects_position_write` — without quirk: setting 70 sends 30; with quirk: setting 70 sends 70