### PR TITLE
Add quirk for Gosund Smart Socket (wifvoilfrqeo6hvu)

### DIFF
--- a/src/tuya_device_handlers/devices/cz/__init__.py
+++ b/src/tuya_device_handlers/devices/cz/__init__.py
@@ -1,0 +1,4 @@
+"""Quirks for Tuya CZ category (socket).
+
+https://developer.tuya.com/en/docs/iot/categorykgczpc?id=Kaiuz08zj1l4y
+"""

--- a/src/tuya_device_handlers/devices/cz/cz_wifvoilfrqeo6hvu.py
+++ b/src/tuya_device_handlers/devices/cz/cz_wifvoilfrqeo6hvu.py
@@ -1,0 +1,58 @@
+"""Quirk for Smart Socket (wifvoilfrqeo6hvu).
+
+The cloud reports wrong type information for the electricity datapoints:
+
+- `cur_voltage` and `cur_power` are declared with `scale=0`, but the
+  device reports deci-volts and deci-watts (e.g. 2306 means 230.6 V).
+- `add_ele` is declared with the unit `度` (Chinese for kWh) and
+  `scale=0`, but the device reports increments of 0.001 kWh.
+
+The voltage maximum is raised from 2500 to 5000 so that mains voltages
+above 250.0 V are not discarded as out-of-range after rescaling.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="wifvoilfrqeo6hvu",
+        manufacturer="Gosund",
+        model="Smart socket",
+        model_id="EP2",
+    )
+    .add_dpid_integer(
+        dpid=3,
+        dpcode="add_ele",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=500000,
+        scale=3,
+        step=1,
+        report_type="sum",
+    )
+    .add_dpid_integer(
+        dpid=5,
+        dpcode="cur_power",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=50000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=6,
+        dpcode="cur_voltage",
+        dpmode=DPMode.READ,
+        unit="V",
+        min=0,
+        max=5000,
+        scale=1,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/cz/__init__.py
+++ b/tests/devices/cz/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya CZ category quirks."""

--- a/tests/devices/cz/test_wifvoilfrqeo6hvu.py
+++ b/tests/devices/cz/test_wifvoilfrqeo6hvu.py
@@ -1,0 +1,73 @@
+"""Test device-level quirk initialisation for CZ devices."""
+
+import json
+
+from tests import create_device
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.device_wrapper.sensor import DeltaIntegerWrapper
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Smart Socket rescales the electricity DPs and fixes the energy unit."""
+    device = create_device("cz_wifvoilfrqeo6hvu.json")
+
+    # The cloud declares scale=0 for voltage/power, so the values read
+    # 10x too high, and reports the energy unit as Chinese for kWh.
+    definitions = get_sensor_default_definitions(device)
+    assert (
+        definitions["cur_voltage"].sensor_wrapper.read_device_status(device)
+        == 2306
+    )
+    assert (
+        definitions["cur_power"].sensor_wrapper.read_device_status(device)
+        == 2941
+    )
+    assert definitions["add_ele"].sensor_wrapper.native_unit == "\u5ea6"
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_sensor_default_definitions(device)
+
+    # Voltage/power are reported in deci-volt/deci-watt
+    assert json.loads(device.status_range["cur_voltage"].values)["max"] == 5000
+
+    voltage_wrapper = definitions["cur_voltage"].sensor_wrapper
+    assert voltage_wrapper.native_unit == "V"
+    assert voltage_wrapper.read_device_status(device) == 230.6
+
+    power_wrapper = definitions["cur_power"].sensor_wrapper
+    assert power_wrapper.native_unit == "W"
+    assert power_wrapper.read_device_status(device) == 294.1
+
+    # Current was already correct and must be untouched
+    current_wrapper = definitions["cur_current"].sensor_wrapper
+    assert current_wrapper.native_unit == "mA"
+    assert current_wrapper.read_device_status(device) == 1275
+
+    # Energy is reported in Wh increments, exposed as kWh
+    energy_wrapper = definitions["add_ele"].sensor_wrapper
+    assert energy_wrapper.native_unit == "kWh"
+
+
+def test_energy_keeps_delta_accumulation(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """add_ele keeps report_type=sum, so deltas are accumulated."""
+    device = create_device("cz_wifvoilfrqeo6hvu.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert device.status_range["add_ele"].report_type == "sum"
+
+    definitions = get_sensor_default_definitions(device)
+    energy_wrapper = definitions["add_ele"].sensor_wrapper
+    assert isinstance(energy_wrapper, DeltaIntegerWrapper)
+
+    # Accumulation starts at 0; a raw delta of 10 is scaled to 0.01 kWh
+    assert energy_wrapper.read_device_status(device) == 0
+    assert not energy_wrapper.skip_update(
+        device, ["add_ele"], dp_timestamps={"add_ele": 123456789}
+    )
+    assert energy_wrapper.read_device_status(device) == 0.01

--- a/tests/fixtures/devices/cz_wifvoilfrqeo6hvu.json
+++ b/tests/fixtures/devices/cz_wifvoilfrqeo6hvu.json
@@ -1,0 +1,137 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Smart Socket",
+  "category": "cz",
+  "product_id": "wifvoilfrqeo6hvu",
+  "product_name": "Smart Socket",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2025-02-06T09:46:45+00:00",
+  "create_time": "2025-02-06T09:46:45+00:00",
+  "update_time": "2025-02-06T09:46:45+00:00",
+  "function": {
+    "switch_1": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"scale\":0,\"unit\":\"\\u79d2\",\"max\":86400,\"step\":1}"
+    }
+  },
+  "status_range": {
+    "switch_1": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"scale\":0,\"unit\":\"\\u79d2\",\"max\":86400,\"step\":1}",
+      "report_type": null
+    },
+    "add_ele": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"scale\":0,\"unit\":\"\\u5ea6\",\"max\":500000,\"step\":100}",
+      "report_type": "sum"
+    },
+    "cur_current": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"scale\":0,\"unit\":\"mA\",\"max\":30000,\"step\":1}",
+      "report_type": null
+    },
+    "cur_power": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"scale\":0,\"unit\":\"W\",\"max\":50000,\"step\":1}",
+      "report_type": null
+    },
+    "cur_voltage": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"unit\":\"V\",\"scale\":0,\"max\":2500,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch_1": true,
+    "countdown_1": 0,
+    "add_ele": 10,
+    "cur_current": 1275,
+    "cur_power": 2941,
+    "cur_voltage": 2306
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch_1",
+      "config_item": {
+        "statusFormat": "{\"switch_1\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "countdown_1",
+      "config_item": {
+        "statusFormat": "{\"countdown_1\":\"$\"}",
+        "valueDesc": "{\"min\":0,\"scale\":0,\"unit\":\"\\u79d2\",\"max\":86400,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "add_ele",
+      "config_item": {
+        "statusFormat": "{\"add_ele\":\"$\"}",
+        "valueDesc": "{\"min\":0,\"scale\":0,\"unit\":\"\\u5ea6\",\"max\":500000,\"step\":100}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "cur_current",
+      "config_item": {
+        "statusFormat": "{\"cur_current\":\"$\"}",
+        "valueDesc": "{\"min\":0,\"scale\":0,\"unit\":\"mA\",\"max\":30000,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "cur_power",
+      "config_item": {
+        "statusFormat": "{\"cur_power\":\"$\"}",
+        "valueDesc": "{\"min\":0,\"scale\":0,\"unit\":\"W\",\"max\":50000,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "cur_voltage",
+      "config_item": {
+        "statusFormat": "{\"cur_voltage\":\"$\"}",
+        "valueDesc": "{\"min\":0,\"unit\":\"V\",\"scale\":0,\"max\":2500,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "wifvoilfrqeo6hvu"
+      }
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
The cloud metadata for this socket (Gosund EP2 hardware) misdeclares its electricity datapoints:

- cur_voltage and cur_power declare scale=0 but the device reports deci-volts/deci-watts, so Home Assistant shows 2306 V instead of 230.6 V and 2941 W instead of 294.1 W.
- add_ele declares the unit 度 (Chinese for kWh) with scale=0 instead of kWh with scale=3, so accumulated energy is off by a factor of 1000.

This is the defect class reported in home-assistant/core#152295: Tuya changed the cloud-side metadata around September 2025, Tuya support declined to correct it ("the manufacturer defines it"), and after a brief server-side fix in December 2025 the wrong metadata returned. The Smart Life app ignores the declared scale and shows correct values, which is how the expected values were confirmed.

The quirk redefines the three datapoints with the correct scale and unit. The voltage maximum is raised to 5000 (matching comparable metering sockets such as guitoc9iylae4axs) so mains voltages above 250.0 V are not rejected as out-of-range after rescaling.

<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
