### PR TITLE
Normalize diagnostics quirk paths in tests

### DIFF
--- a/tests/helpers/test_diagnostics.py
+++ b/tests/helpers/test_diagnostics.py
@@ -16,7 +16,7 @@ _PROJECT_ROOT = pathlib.Path(__file__).parents[2]
 def _relative_quirk(quirk: str) -> str:
     """Return the quirk reference as a path relative to the project root."""
     path, _, line = quirk.rpartition(":")
-    return f"{pathlib.Path(path).relative_to(_PROJECT_ROOT)}:{line}"
+    return f"{pathlib.Path(path).relative_to(_PROJECT_ROOT).as_posix()}:{line}"
 
 
 def test_customer_device_as_dict(snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
## Summary

Normalize the diagnostics test helper to compare quirk paths using POSIX separators. This keeps the existing snapshots stable when the test suite is run on Windows while preserving the same quirk provenance information.

## Test plan

- poetry run pytest tests/helpers/test_diagnostics.py
- Fork CI: Linting, Typing, Testing

## Notes

Draft PR split out from the socket quirk work per maintainer request.