### PR TITLE
Add quirk for GHome Mini Smart Plug (qxJSyTLEtX5WrzA9)

### DIFF
--- a/src/tuya_device_handlers/devices/cz/cz_qxjsytletx5wrza9.py
+++ b/src/tuya_device_handlers/devices/cz/cz_qxjsytletx5wrza9.py
@@ -1,0 +1,42 @@
+"""Quirk for Mini Smart Plug (qxJSyTLEtX5WrzA9).
+
+The cloud reports wrong type information for the electricity datapoints:
+
+- `cur_power` is declared with `scale=0`, but the device reports
+  deci-watts (e.g. 2941 means 294.1 W).
+- `cur_voltage` is declared with `scale=0`, but the device reports
+  deci-volts (e.g. 2306 means 230.6 V).
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="qxJSyTLEtX5WrzA9",
+        model="Mini Smart Plug",
+    )
+    .add_dpid_integer(
+        dpid=5,
+        dpcode="cur_power",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=50000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=6,
+        dpcode="cur_voltage",
+        dpmode=DPMode.READ,
+        unit="V",
+        min=0,
+        max=3000,
+        scale=1,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/cz/cz_qxjsytletx5wrza9.py
+++ b/src/tuya_device_handlers/devices/cz/cz_qxjsytletx5wrza9.py
@@ -16,7 +16,9 @@ from tuya_device_handlers.const import DPMode
     DeviceQuirk()
     .applies_to(
         product_id="qxJSyTLEtX5WrzA9",
+        manufacturer="GHome",
         model="Mini Smart Plug",
+        model_id="WP3",
     )
     .add_dpid_integer(
         dpid=5,

--- a/tests/devices/cz/test_qxjsytletx5wrza9.py
+++ b/tests/devices/cz/test_qxjsytletx5wrza9.py
@@ -1,0 +1,37 @@
+"""Test device-level quirk initialisation for CZ devices."""
+
+from tests import create_device
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides_power_and_voltage_scaling(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Mini Smart Plug reports power and voltage in deci-units."""
+    device = create_device("cz_qxjsytletx5wrza9.json")
+
+    definitions = get_sensor_default_definitions(device)
+    assert (
+        definitions["cur_power"].sensor_wrapper.read_device_status(device)
+        == 2941
+    )
+    assert (
+        definitions["cur_voltage"].sensor_wrapper.read_device_status(device)
+        == 2306
+    )
+
+    filled_quirks_registry.initialise_device_quirk(device)
+    definitions = get_sensor_default_definitions(device)
+
+    power_wrapper = definitions["cur_power"].sensor_wrapper
+    assert power_wrapper.native_unit == "W"
+    assert power_wrapper.read_device_status(device) == 294.1
+
+    voltage_wrapper = definitions["cur_voltage"].sensor_wrapper
+    assert voltage_wrapper.native_unit == "V"
+    assert voltage_wrapper.read_device_status(device) == 230.6
+
+    current_wrapper = definitions["cur_current"].sensor_wrapper
+    assert current_wrapper.native_unit == "mA"
+    assert current_wrapper.read_device_status(device) == 1275

--- a/tests/devices/cz/test_qxjsytletx5wrza9.py
+++ b/tests/devices/cz/test_qxjsytletx5wrza9.py
@@ -1,5 +1,7 @@
 """Test device-level quirk initialisation for CZ devices."""
 
+import pytest
+
 from tests import create_device
 from tests.integration_helpers.sensor import get_sensor_default_definitions
 from tuya_device_handlers.registry import QuirksRegistry
@@ -26,11 +28,11 @@ def test_quirk_overrides_power_and_voltage_scaling(
 
     power_wrapper = definitions["cur_power"].sensor_wrapper
     assert power_wrapper.native_unit == "W"
-    assert power_wrapper.read_device_status(device) == 294.1
+    assert power_wrapper.read_device_status(device) == pytest.approx(294.1)
 
     voltage_wrapper = definitions["cur_voltage"].sensor_wrapper
     assert voltage_wrapper.native_unit == "V"
-    assert voltage_wrapper.read_device_status(device) == 230.6
+    assert voltage_wrapper.read_device_status(device) == pytest.approx(230.6)
 
     current_wrapper = definitions["cur_current"].sensor_wrapper
     assert current_wrapper.native_unit == "mA"

--- a/tests/devices/cz/test_qxjsytletx5wrza9.py
+++ b/tests/devices/cz/test_qxjsytletx5wrza9.py
@@ -16,11 +16,11 @@ def test_quirk_overrides_power_and_voltage_scaling(
     definitions = get_sensor_default_definitions(device)
     assert (
         definitions["cur_power"].sensor_wrapper.read_device_status(device)
-        == 2941
+        == 2082
     )
     assert (
         definitions["cur_voltage"].sensor_wrapper.read_device_status(device)
-        == 2306
+        == 2341
     )
 
     filled_quirks_registry.initialise_device_quirk(device)
@@ -28,12 +28,12 @@ def test_quirk_overrides_power_and_voltage_scaling(
 
     power_wrapper = definitions["cur_power"].sensor_wrapper
     assert power_wrapper.native_unit == "W"
-    assert power_wrapper.read_device_status(device) == pytest.approx(294.1)
+    assert power_wrapper.read_device_status(device) == pytest.approx(208.2)
 
     voltage_wrapper = definitions["cur_voltage"].sensor_wrapper
     assert voltage_wrapper.native_unit == "V"
-    assert voltage_wrapper.read_device_status(device) == pytest.approx(230.6)
+    assert voltage_wrapper.read_device_status(device) == pytest.approx(234.1)
 
     current_wrapper = definitions["cur_current"].sensor_wrapper
     assert current_wrapper.native_unit == "mA"
-    assert current_wrapper.read_device_status(device) == 1275
+    assert current_wrapper.read_device_status(device) == 925

--- a/tests/fixtures/devices/cz_qxjsytletx5wrza9.json
+++ b/tests/fixtures/devices/cz_qxjsytletx5wrza9.json
@@ -20,45 +20,9 @@
     },
     "countdown_1": {
       "type": "Integer",
-      "value": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
+      "value": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
     }
   },
-  "status_range": {
-    "switch": {
-      "type": "Boolean",
-      "value": "{}",
-      "report_type": null
-    },
-    "countdown_1": {
-      "type": "Integer",
-      "value": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "cur_current": {
-      "type": "Integer",
-      "value": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "cur_power": {
-      "type": "Integer",
-      "value": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
-      "report_type": null
-    },
-    "cur_voltage": {
-      "type": "Integer",
-      "value": "{\"unit\":\"V\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
-      "report_type": null
-    }
-  },
-  "status": {
-    "switch": true,
-    "countdown_1": 0,
-    "cur_current": 1275,
-    "cur_power": 2941,
-    "cur_voltage": 2306
-  },
-  "set_up": true,
-  "support_local": true,
   "local_strategy": {
     "1": {
       "value_convert": "default",
@@ -76,7 +40,7 @@
       "status_code": "countdown_1",
       "config_item": {
         "statusFormat": "{\"countdown_1\":\"$\"}",
-        "valueDesc": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+        "valueDesc": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
         "valueType": "Integer",
         "enumMappingMap": {},
         "pid": "qxJSyTLEtX5WrzA9"
@@ -116,5 +80,42 @@
       }
     }
   },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_power": {
+      "type": "Integer",
+      "value": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_voltage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"V\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "countdown_1": 0,
+    "cur_current": 925,
+    "cur_power": 2082,
+    "cur_voltage": 2341
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": null,
   "warnings": null
 }

--- a/tests/fixtures/devices/cz_qxjsytletx5wrza9.json
+++ b/tests/fixtures/devices/cz_qxjsytletx5wrza9.json
@@ -1,0 +1,120 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Server SR650",
+  "category": "cz",
+  "product_id": "qxJSyTLEtX5WrzA9",
+  "product_name": "Mini Smart Plug",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2024-11-10T13:39:24+00:00",
+  "create_time": "2024-11-10T13:39:24+00:00",
+  "update_time": "2024-11-10T13:39:24+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_power": {
+      "type": "Integer",
+      "value": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_voltage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"V\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "countdown_1": 0,
+    "cur_current": 1275,
+    "cur_power": 2941,
+    "cur_voltage": 2306
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "qxJSyTLEtX5WrzA9"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "countdown_1",
+      "config_item": {
+        "statusFormat": "{\"countdown_1\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\\u79d2\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "qxJSyTLEtX5WrzA9"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "cur_current",
+      "config_item": {
+        "statusFormat": "{\"cur_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "qxJSyTLEtX5WrzA9"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "cur_power",
+      "config_item": {
+        "statusFormat": "{\"cur_power\":\"$\"}",
+        "valueDesc": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "qxJSyTLEtX5WrzA9"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "cur_voltage",
+      "config_item": {
+        "statusFormat": "{\"cur_voltage\":\"$\"}",
+        "valueDesc": "{\"unit\":\"V\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "qxJSyTLEtX5WrzA9"
+      }
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

Adds a focused CZ device quirk for a Mini Smart Plug where Tuya reports power and voltage with the wrong scale. The quirk changes both readings to deci-units while leaving current unchanged.

The fixture was rebuilt from the original Home Assistant diagnostics payload according to the documented fixture workflow.

## Test plan

- poetry run pytest tests/devices/cz/test_qxjsytletx5wrza9.py
- The issue reporter should verify on the physical plug that Home Assistant power and voltage now match the Tuya app instead of being ten times too high.
- The issue reporter should confirm current readings remain unchanged.

## Related issue

Part of #265