### PR TITLE
Add quirk for WVC micro inverter (7bqwya0ydtz4q3ss)

### DIFF
--- a/src/tuya_device_handlers/devices/znnbq/__init__.py
+++ b/src/tuya_device_handlers/devices/znnbq/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for Tuya ZNNBQ category (undocumented)."""

--- a/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
+++ b/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
@@ -1,0 +1,39 @@
+"""Quirk for WVC micro inverter.
+
+Tuya reports `power_total` as `unit="kW"` with `scale=3`.
+For this device the raw value represents watts with scale 3.
+
+Example from diagnostics before applying the quirk:
+    raw power_total = 308022
+
+Incorrect interpretation:
+    308022 / 1000 = 308.022 kW = 308022 W
+
+Correct interpretation:
+    308022 / 1000 = 308.022 W
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="7bqwya0ydtz4q3ss",
+        manufacturer="WVC",
+        model="Micro inverter",
+        model_id="WVC-800W",
+    )
+    .add_dpid_integer(
+        dpid=10,
+        dpcode="power_total",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=50000000,
+        scale=3,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
+++ b/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
@@ -1,0 +1,37 @@
+"""Quirk for WVC micro inverter.
+
+Tuya reports `power_total` as `unit="kW"` with `scale=3`.
+For this device the raw value represents watts with scale 3.
+
+Example from diagnostics before applying the quirk:
+    raw power_total = 308022
+
+Incorrect interpretation:
+    308022 / 1000 = 308.022 kW = 308022 W
+
+Correct interpretation:
+    308022 / 1000 = 308.022 W
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="7bqwya0ydtz4q3ss",
+    )
+    .add_dpid_integer(
+        dpid=10,
+        dpcode="power_total",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=50000000,
+        scale=3,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
+++ b/src/tuya_device_handlers/devices/znnbq/znnbq_7bqwya0ydtz4q3ss.py
@@ -17,7 +17,6 @@ from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.builder import DeviceQuirk
 from tuya_device_handlers.const import DPMode
 
-
 (
     DeviceQuirk()
     .applies_to(

--- a/tests/devices/znnbq/__init__.py
+++ b/tests/devices/znnbq/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya ZNNBQ category (undocumented) quirks."""

--- a/tests/devices/znnbq/test_7bqwya0ydtz4q3ss.py
+++ b/tests/devices/znnbq/test_7bqwya0ydtz4q3ss.py
@@ -1,7 +1,5 @@
 """Test device-level quirk initialisation for ZNNBQ devices."""
 
-import pytest
-
 from tests import create_device
 from tests.integration_helpers.sensor import get_sensor_default_definitions
 from tuya_device_handlers.registry import QuirksRegistry
@@ -10,11 +8,8 @@ from tuya_device_handlers.registry import QuirksRegistry
 def test_quirk_overrides_wvc_micro_inverter_power_unit(
     filled_quirks_registry: QuirksRegistry,
 ) -> None:
-    """WVC micro inverter reports power_total as kW scale 3 instead of W scale 3."""
+    """WVC micro inverter reports power_total as kW instead of W."""
     device = create_device("znnbq_7bqwya0ydtz4q3ss.json")
-
-    raw_power_total = float(device.status["power_total"])
-    expected_scaled_value = raw_power_total / 1000.0
 
     definitions = get_sensor_default_definitions(device)
     power_wrapper = definitions["power_total"].sensor_wrapper
@@ -23,9 +18,7 @@ def test_quirk_overrides_wvc_micro_inverter_power_unit(
     # This gives a native value like 179.641 kW, which Home Assistant later
     # exposes as 179641 W.
     assert power_wrapper.native_unit == "kW"
-    assert power_wrapper.read_device_status(device) == pytest.approx(
-        expected_scaled_value
-    )
+    assert power_wrapper.read_device_status(device) == 179.641
 
     filled_quirks_registry.initialise_device_quirk(device)
 
@@ -34,6 +27,4 @@ def test_quirk_overrides_wvc_micro_inverter_power_unit(
 
     # After the quirk, the same scaled native value is correctly expressed in W.
     assert power_wrapper.native_unit == "W"
-    assert power_wrapper.read_device_status(device) == pytest.approx(
-        expected_scaled_value
-    )
+    assert power_wrapper.read_device_status(device) == 179.641

--- a/tests/devices/znnbq/test_7bqwya0ydtz4q3ss.py
+++ b/tests/devices/znnbq/test_7bqwya0ydtz4q3ss.py
@@ -1,0 +1,39 @@
+"""Test device-level quirk initialisation for ZNNBQ devices."""
+
+import pytest
+
+from tests import create_device
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides_wvc_micro_inverter_power_unit(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """WVC micro inverter reports power_total as kW scale 3 instead of W scale 3."""
+    device = create_device("znnbq_7bqwya0ydtz4q3ss.json")
+
+    raw_power_total = float(device.status["power_total"])
+    expected_scaled_value = raw_power_total / 1000.0
+
+    definitions = get_sensor_default_definitions(device)
+    power_wrapper = definitions["power_total"].sensor_wrapper
+
+    # Before the quirk, the cloud metadata declares kW with scale 3.
+    # This gives a native value like 179.641 kW, which Home Assistant later
+    # exposes as 179641 W.
+    assert power_wrapper.native_unit == "kW"
+    assert power_wrapper.read_device_status(device) == pytest.approx(
+        expected_scaled_value
+    )
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_sensor_default_definitions(device)
+    power_wrapper = definitions["power_total"].sensor_wrapper
+
+    # After the quirk, the same scaled native value is correctly expressed in W.
+    assert power_wrapper.native_unit == "W"
+    assert power_wrapper.read_device_status(device) == pytest.approx(
+        expected_scaled_value
+    )

--- a/tests/fixtures/devices/znnbq_7bqwya0ydtz4q3ss.json
+++ b/tests/fixtures/devices/znnbq_7bqwya0ydtz4q3ss.json
@@ -1,0 +1,98 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "WVC Mikro-Wechselrichter",
+  "category": "znnbq",
+  "product_id": "7bqwya0ydtz4q3ss",
+  "product_name": "WVC-micro inverter",
+  "online": true,
+  "sub": false,
+  "time_zone": "+02:00",
+  "active_time": "2023-10-08T14:03:42+00:00",
+  "create_time": "2023-10-08T14:03:42+00:00",
+  "update_time": "2023-10-08T14:03:42+00:00",
+  "function": {
+    "work_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"power_off\",\"inverter_power\",\"grid_power\",\"battery_power\"]}"
+    }
+  },
+  "local_strategy": {
+    "2": {
+      "value_convert": "default",
+      "status_code": "reverse_energy_total",
+      "config_item": {
+        "statusFormat": "{\"reverse_energy_total\":\"$\"}",
+        "valueDesc": "{\"unit\":\"kW·h\",\"min\":0,\"max\":99999999,\"scale\":2,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "7bqwya0ydtz4q3ss"
+      }
+    },
+    "10": {
+      "value_convert": "default",
+      "status_code": "power_total",
+      "config_item": {
+        "statusFormat": "{\"power_total\":\"$\"}",
+        "valueDesc": "{\"unit\":\"kW\",\"min\":0,\"max\":50000000,\"scale\":3,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "7bqwya0ydtz4q3ss"
+      }
+    },
+    "12": {
+      "value_convert": "default",
+      "status_code": "work_mode",
+      "config_item": {
+        "statusFormat": "{\"work_mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"power_off\",\"inverter_power\",\"grid_power\",\"battery_power\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "7bqwya0ydtz4q3ss"
+      }
+    },
+    "18": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"℃\",\"min\":-40,\"max\":150,\"scale\":1,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "7bqwya0ydtz4q3ss"
+      }
+    }
+  },
+  "status_range": {
+    "reverse_energy_total": {
+      "type": "Integer",
+      "value": "{\"unit\":\"kW·h\",\"min\":0,\"max\":99999999,\"scale\":2,\"step\":1}",
+      "report_type": "minux"
+    },
+    "power_total": {
+      "type": "Integer",
+      "value": "{\"unit\":\"kW\",\"min\":0,\"max\":50000000,\"scale\":3,\"step\":1}",
+      "report_type": "un_known"
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"power_off\",\"inverter_power\",\"grid_power\",\"battery_power\"]}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":-40,\"max\":150,\"scale\":1,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "reverse_energy_total": 115440,
+    "power_total": 179641,
+    "work_mode": "power_off",
+    "temp_current": 33
+  },
+  "set_up": true,
+  "support_local": true
+}


### PR DESCRIPTION
**Summary**

Adds a device quirk for a Tuya WVC micro inverter with product_id `7bqwya0ydtz4q3ss`.

The device reports `power_total` as `unit="kW"` with `scale=3`. This produces a native value such as `179.641 kW`, which Home Assistant later exposes as `179641 W`.

For this device, the raw value represents watts with scale 3, so the expected interpretation is `179.641 W`.

This quirk changes the `power_total` metadata from `unit="kW"` to `unit="W"` while keeping `scale=3`.

Before the quirk:

* cloud metadata: `unit="kW"`, `scale=3`
* raw `power_total`: values such as `179641`
* exposed value in Home Assistant: `179641 W`

After the quirk:

* patched metadata: `unit="W"`, `scale=3`
* exposed value in Home Assistant: `179.641 W`

The inverter is connected to 2 × 400 W PV modules, so values around 100–800 W are plausible, while values above 100000 W are physically impossible.

**Test plan**

Tested locally in Home Assistant OS 2026.6.2 using a local custom quirk:

`/config/tuya_quirks/znnbq_7bqwya0ydtz4q3ss.py`

The diagnostics confirmed that the local quirk was loaded, and the power sensor changed from physically impossible values in the hundreds of kW range to plausible watt values.

Ran successfully:

```bash
poetry run pytest tests/devices/znnbq/test_7bqwya0ydtz4q3ss.py -vv
poetry run pytest tests/devices/znnbq -vv
poetry run pytest tests -q
```

Result:

```text
398 passed
41 snapshots passed
```

**Related issue**

home-assistant/core#173429
