### PR TITLE
Add quirk for Metered electrical outlet (QH3oyDNHKw9c1irH)

### DIFF
--- a/src/tuya_device_handlers/devices/cz/cz_qh3oydnhkw9c1irh.py
+++ b/src/tuya_device_handlers/devices/cz/cz_qh3oydnhkw9c1irh.py
@@ -1,0 +1,39 @@
+"""Quirk for Metered electrical outlet (QH3oyDNHKw9c1irH).
+
+The cloud reports wrong type information for the electricity datapoints:
+
+- `cur_power` is declared with `scale=0`, but the device reports
+  deci-watts (e.g. 4681 means 468.1 W).
+- `cur_voltage` is declared with `scale=0`, but the device reports
+  deci-volts (e.g. 1156 means 115.6 V).
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="QH3oyDNHKw9c1irH")
+    .add_dpid_integer(
+        dpid=5,
+        dpcode="cur_power",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=50000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=6,
+        dpcode="cur_voltage",
+        dpmode=DPMode.READ,
+        unit="V",
+        min=0,
+        max=2500,
+        scale=1,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/cz/test_qh3oydnhkw9c1irh.py
+++ b/tests/devices/cz/test_qh3oydnhkw9c1irh.py
@@ -1,0 +1,39 @@
+"""Test device-level quirk initialisation for CZ devices."""
+
+import pytest
+
+from tests import create_device
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides_power_and_voltage_scaling(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Metered electrical outlet reports power and voltage in deci-units."""
+    device = create_device("cz_qh3oydnhkw9c1irh.json")
+
+    definitions = get_sensor_default_definitions(device)
+    assert (
+        definitions["cur_power"].sensor_wrapper.read_device_status(device)
+        == 4681
+    )
+    assert (
+        definitions["cur_voltage"].sensor_wrapper.read_device_status(device)
+        == 1156
+    )
+
+    filled_quirks_registry.initialise_device_quirk(device)
+    definitions = get_sensor_default_definitions(device)
+
+    power_wrapper = definitions["cur_power"].sensor_wrapper
+    assert power_wrapper.native_unit == "W"
+    assert power_wrapper.read_device_status(device) == pytest.approx(468.1)
+
+    voltage_wrapper = definitions["cur_voltage"].sensor_wrapper
+    assert voltage_wrapper.native_unit == "V"
+    assert voltage_wrapper.read_device_status(device) == pytest.approx(115.6)
+
+    current_wrapper = definitions["cur_current"].sensor_wrapper
+    assert current_wrapper.native_unit == "mA"
+    assert current_wrapper.read_device_status(device) == 4178

--- a/tests/fixtures/devices/cz_qh3oydnhkw9c1irh.json
+++ b/tests/fixtures/devices/cz_qh3oydnhkw9c1irh.json
@@ -1,0 +1,121 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Metered electrical outlet",
+  "category": "cz",
+  "product_id": "QH3oyDNHKw9c1irH",
+  "product_name": "JL",
+  "online": true,
+  "sub": false,
+  "time_zone": "-05:00",
+  "active_time": "2026-06-06T14:55:00+00:00",
+  "create_time": "2026-06-06T14:55:00+00:00",
+  "update_time": "2026-06-06T14:55:00+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
+    }
+  },
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "QH3oyDNHKw9c1irH"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "countdown_1",
+      "config_item": {
+        "statusFormat": "{\"countdown_1\":\"$\"}",
+        "valueDesc": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "QH3oyDNHKw9c1irH"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "cur_current",
+      "config_item": {
+        "statusFormat": "{\"cur_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "QH3oyDNHKw9c1irH"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "cur_power",
+      "config_item": {
+        "statusFormat": "{\"cur_power\":\"$\"}",
+        "valueDesc": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "QH3oyDNHKw9c1irH"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "cur_voltage",
+      "config_item": {
+        "statusFormat": "{\"cur_voltage\":\"$\"}",
+        "valueDesc": "{\"unit\":\"V\",\"min\":0,\"max\":2500,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "QH3oyDNHKw9c1irH"
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_1": {
+      "type": "Integer",
+      "value": "{\"unit\":\"秒\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_power": {
+      "type": "Integer",
+      "value": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "cur_voltage": {
+      "type": "Integer",
+      "value": "{\"unit\":\"V\",\"min\":0,\"max\":2500,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "countdown_1": 0,
+    "cur_current": 4178,
+    "cur_power": 4681,
+    "cur_voltage": 1156
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": null,
+  "warnings": null
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Fixes power and voltage showing wrong scale on a smart socket device (XS-SSA05).  This device seems to be sold under several brands including Famirosa.

Power/Voltage are reported in deci-units so need to be divided by 10.

## Test plan

<!-- How was it tested? -->
Validated with real device.  Added tests as per documentation.

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
N/A