### PR TITLE
Add quirk for WiFi smart online 5 in 1 tester (qajfz5x1lqej5xxw)

### DIFF
--- a/src/tuya_device_handlers/devices/dgnbj/__init__.py
+++ b/src/tuya_device_handlers/devices/dgnbj/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for the Tuya DGNBJ category (multi-functional alarm host)."""

--- a/src/tuya_device_handlers/devices/dgnbj/dgnbj_qajfz5x1lqej5xxw.py
+++ b/src/tuya_device_handlers/devices/dgnbj/dgnbj_qajfz5x1lqej5xxw.py
@@ -7,7 +7,7 @@ are reported over MQTT on datapoints that are missing from the cloud data
 model, so the sharing SDK drops them as "unknown dpId" and Home Assistant
 never builds the corresponding entities.
 
-This quirk re-declares the pH datapoint (dp 102) so Home Assistant builds the
+This quirk redeclares the pH datapoint (dp 102) so Home Assistant builds the
 pH sensor. The scale was confirmed against the Tuya Smart Life app
 (raw value 939 -> 9.39 pH).
 """

--- a/src/tuya_device_handlers/devices/dgnbj/dgnbj_qajfz5x1lqej5xxw.py
+++ b/src/tuya_device_handlers/devices/dgnbj/dgnbj_qajfz5x1lqej5xxw.py
@@ -1,0 +1,33 @@
+"""Quirk for the Tuya "WiFi smart online 5 in 1 tester" (qajfz5x1lqej5xxw).
+
+Category ``dgnbj``. The cloud data model for this device only exposes
+``temp_current`` (dp 8), even though the device also measures pH (and, with a
+wet and calibrated probe, EC / salinity / specific gravity). The extra values
+are reported over MQTT on datapoints that are missing from the cloud data
+model, so the sharing SDK drops them as "unknown dpId" and Home Assistant
+never builds the corresponding entities.
+
+This quirk re-declares the pH datapoint (dp 102) so Home Assistant builds the
+pH sensor. The scale was confirmed against the Tuya Smart Life app
+(raw value 939 -> 9.39 pH).
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="qajfz5x1lqej5xxw")
+    .add_dpid_integer(
+        dpid=102,
+        dpcode="ph_current",
+        dpmode=DPMode.READ,
+        unit="ph",
+        min=0,
+        max=1400,
+        scale=2,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/dgnbj/__init__.py
+++ b/tests/devices/dgnbj/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya DGNBJ category (multi-functional alarm host) quirks."""

--- a/tests/devices/dgnbj/test_qajfz5x1lqej5xxw.py
+++ b/tests/devices/dgnbj/test_qajfz5x1lqej5xxw.py
@@ -1,0 +1,37 @@
+"""Test device-level quirk initialisation for the 5 in 1 tester (dgnbj)."""
+
+from tests import create_device
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """The 5 in 1 tester registers the ph_current DP."""
+    device = create_device("dgnbj_qajfz5x1lqej5xxw.json")
+
+    assert "temp_current" in device.status_range
+    assert "ph_current" not in device.status_range
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert "temp_current" in device.status_range
+    assert "ph_current" in device.status_range
+
+
+def test_default_definitions(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """The 5 in 1 tester exposes the pH sensor after the quirk."""
+    device = create_device("dgnbj_qajfz5x1lqej5xxw.json")
+
+    definitions = get_sensor_default_definitions(device)
+    assert "temp_current" in definitions
+    assert "ph_current" not in definitions
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_sensor_default_definitions(device)
+    assert "temp_current" in definitions
+    assert "ph_current" in definitions

--- a/tests/fixtures/devices/dgnbj_qajfz5x1lqej5xxw.json
+++ b/tests/fixtures/devices/dgnbj_qajfz5x1lqej5xxw.json
@@ -1,0 +1,44 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "WiFi smart  online 5 in 1 tester",
+  "category": "dgnbj",
+  "product_id": "qajfz5x1lqej5xxw",
+  "product_name": "WiFi smart  online 5 in 1 tester",
+  "online": true,
+  "sub": false,
+  "time_zone": "+02:00",
+  "active_time": "2026-06-29T16:19:58+00:00",
+  "create_time": "2026-06-29T16:19:58+00:00",
+  "update_time": "2026-06-29T16:19:58+00:00",
+  "function": {},
+  "local_strategy": {
+    "8": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"℃\",\"min\":-100,\"max\":1100,\"scale\":1,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "qajfz5x1lqej5xxw"
+      }
+    }
+  },
+  "status_range": {
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":-100,\"max\":1100,\"scale\":1,\"step\":1}",
+      "report_type": "un_known"
+    }
+  },
+  "status": {
+    "temp_current": 296
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": null,
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

Adds a quirk for the Tuya **WiFi smart online 5 in 1 tester** (`product_id qajfz5x1lqej5xxw`, category `dgnbj`) — a WiFi pool/aquarium water-quality tester.

The cloud data model for this device only exposes `temp_current` (dp 8), so Home Assistant only builds the temperature sensor. The device actually reports more over MQTT, but on datapoints that are absent from the data model, which the sharing SDK drops as `unknown dpId`.

Live debug logs show the device pushes `dp 8, 101, 102, 107, 110, 113, 116, 119`. This quirk declares **pH** (`dp 102` → `ph_current`, scale 2), a code HA core already maps for the `dgnbj` category (home-assistant/core#159584).

The scale was confirmed by exact value match against the Tuya Smart Life app:

| dp | raw | scale | value | app |
|----|-----|-------|-------|-----|
| 8   | 297 | 1 | 29.7 | 29.7 °C |
| 102 | 939 | 2 | 9.39 | 9.39 pH |

EC / salinity / specific gravity / ORP currently read `0` on this unit (dry/uncalibrated conductivity electrode), so their dpIds can't be confirmed yet; they are intentionally left out and can be added in a follow-up.

## Test plan

- New fixture `tests/fixtures/devices/dgnbj_qajfz5x1lqej5xxw.json` (from device diagnostics; `temp_current` only).
- New tests assert the quirk adds `ph_current` to `status_range` and to the default sensor definitions.
- `pytest`: **414 passed**; `ruff check` and `ruff format --check` clean.
- Validated live on Home Assistant 2026.7 via `/config/tuya_quirks/`: the `pH` entity appears and reports `9.39`.

## Related issue

_None._