### PR TITLE
Create binary sensor for declared-but-unreported dpcode

### DIFF
--- a/src/tuya_device_handlers/definition/binary_sensor.py
+++ b/src/tuya_device_handlers/definition/binary_sensor.py
@@ -50,7 +50,11 @@ def get_default_definition(
         return BinarySensorDefinition(binary_sensor_wrapper=bool_type)
 
     # Legacy / compatibility
-    if dpcode not in device.status:
+    if not (
+        dpcode in device.function
+        or dpcode in device.status
+        or dpcode in device.status_range
+    ):
         return None
     return BinarySensorDefinition(
         binary_sensor_wrapper=DPCodeInSetWrapper(


### PR DESCRIPTION
## Summary

The enum/`DPCodeInSetWrapper` fallback in `get_default_definition` (binary_sensor) only created an entity when a value was **already present** in `device.status`. A device that *declares* a dpcode (`function`/`status_range`) but has not yet reported a value — e.g. a PIR motion sensor before its first report — would get no entity, forcing quirks to seed `device.status` (`setdefault("pir", "none")`).

This aligns the check with the existing pattern in `fan.py` and `humidifier.py`: create the entity when the dpcode is declared in `function`/`status`/`status_range`.

```python
# Legacy / compatibility
if not (
    dpcode in device.function
    or dpcode in device.status
    or dpcode in device.status_range
):
    return None
```

## Why this is safe

- **Additive.** It only creates entities that a declared enum dpcode would previously have missed; it never removes an entity that used to exist.
- **Honest state.** `DPCodeInSetWrapper.read_device_status` reads `device.status.get(dpcode)` → `None` until the first report, so the binary sensor is `unknown` rather than a falsely-seeded "clear".
- binary_sensor was the only platform with this gap — every other platform already resolves via `<Wrapper>.find_dpcode(...)` (type information), not a reported value.

## Test plan

- [x] `ruff check` / `ruff format`
- [x] `ty check`
- [x] `pytest tests/definition/test_binary_sensor.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
