### PR TITLE
Normalise null local_strategy in test create_device helper

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,6 +91,11 @@ def create_device(fixture_filename: str) -> CustomerDevice:
         status=details["status"],
     )
 
+    # A real local device always exposes a local_strategy dict; a diagnostics
+    # fixture may capture it as null, so mirror the real-world invariant here.
+    if device.support_local and device.local_strategy is None:
+        device.local_strategy = {}
+
     for key, value in device.status.items():
         # Some devices do not provide a status_range for all status DPs
         # Others set the type as String in status_range and as Json in function

--- a/tests/helpers/__snapshots__/test_diagnostics.ambr
+++ b/tests/helpers/__snapshots__/test_diagnostics.ambr
@@ -71,7 +71,8 @@
       }),
     }),
     'id': 'cijerqyssiwrf7de',
-    'local_strategy': None,
+    'local_strategy': dict({
+    }),
     'name': '接HA水阀',
     'online': True,
     'product_id': 'ed7frwissyqrejic',


### PR DESCRIPTION
## Summary

A real local device (`support_local=True`) always exposes `local_strategy` as a dict, but a diagnostics fixture can capture it as `null`. This forced individual tests to guard against `None` before `initialise_device_quirk`, e.g.:

```python
# Prevent error if local_strategy is None when device.support_local is True
if device.support_local and device.local_strategy is None:
    device.local_strategy = {}
```

This mirrors the real-world invariant in the `create_device` test helper: when `support_local` is `True` and the fixture's `local_strategy` is `null`, normalise it to an empty dict. Individual tests (e.g. the feed_report test in #349) no longer need the workaround.

The `test_diagnostics` snapshot is updated to reflect `{}` instead of `null` for the affected fixture.

## Test plan

- [x] `ruff check`
- [x] `pytest` (full suite, 411 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)