### PR TITLE
Add Tuya blind motor quirk for xyakonle1azq2xgn

### DIFF
--- a/src/tuya_device_handlers/devices/cl/cl_xyakonle1azq2xgn.py
+++ b/src/tuya_device_handlers/devices/cl/cl_xyakonle1azq2xgn.py
@@ -1,0 +1,18 @@
+"""Quirk for Tuya blind motor (product_id xyakonle1azq2xgn).
+
+This device does reports ``percent_state`` always as 0.
+
+To be able to control the device, we need to ignore the 
+``percent_control`` and ``percent_state`` DPs.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="xyakonle1azq2xgn")
+    .remove_dpid(dpid=9, dpcode="percent_control")
+    .remove_dpid(dpid=8, dpcode="percent_state")
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/cl/cl_xyakonle1azq2xgn.py
+++ b/src/tuya_device_handlers/devices/cl/cl_xyakonle1azq2xgn.py
@@ -1,8 +1,8 @@
 """Quirk for Tuya blind motor (product_id xyakonle1azq2xgn).
 
-This device does reports ``percent_state`` always as 0.
+This device always reports percent_state as 0.
 
-To be able to control the device, we need to ignore the 
+To be able to control the device, we need to ignore the
 ``percent_control`` and ``percent_state`` DPs.
 """
 

--- a/tests/devices/cl/test_xyakonle1azq2xgn.py
+++ b/tests/devices/cl/test_xyakonle1azq2xgn.py
@@ -1,0 +1,31 @@
+"""Quirk test for Tuya blind motor (product_id xyakonle1azq2xgn)."""
+
+from unittest.mock import patch
+
+from tests import create_device
+from tests.integration_helpers.cover import get_cover_default_definitions
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_removed_position(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """With quirk, no position wrapper should exist."""
+    device = create_device("cl_xyakonle1azq2xgn.json")
+    device.status["percent_state"] = 0
+
+    with patch.dict(TUYA_QUIRKS_REGISTRY._quirks, clear=True):
+        definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].current_position_wrapper
+    assert wrapper is not None
+    wrapper = definitions["control"].set_position_wrapper
+    assert wrapper is not None
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_cover_default_definitions(device)
+    wrapper = definitions["control"].current_position_wrapper
+    assert wrapper is None
+    wrapper = definitions["control"].set_position_wrapper
+    assert wrapper is None

--- a/tests/fixtures/devices/cl_xyakonle1azq2xgn.json
+++ b/tests/fixtures/devices/cl_xyakonle1azq2xgn.json
@@ -1,0 +1,146 @@
+{
+  "endpoint": "**REDACTED**",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Toldo 01 - Gourmet Frente",
+  "category": "cl",
+  "product_id": "xyakonle1azq2xgn",
+  "product_name": "Motor WI-FI EMTECO",
+  "online": true,
+  "sub": false,
+  "time_zone": "-03:00",
+  "active_time": "2026-06-30T23:02:07+00:00",
+  "create_time": "2026-06-30T23:02:07+00:00",
+  "update_time": "2026-06-30T23:02:07+00:00",
+  "function": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}"
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}"
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}"
+    }
+  },
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "control",
+      "config_item": {
+        "statusFormat": "{\"control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "work_state",
+      "config_item": {
+        "statusFormat": "{\"work_state\":\"$\"}",
+        "valueDesc": "{\"range\":[\"opening\",\"closing\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    },
+    "8": {
+      "value_convert": "default",
+      "status_code": "percent_state",
+      "config_item": {
+        "statusFormat": "{\"percent_state\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    },
+    "9": {
+      "value_convert": "default",
+      "status_code": "percent_control",
+      "config_item": {
+        "statusFormat": "{\"percent_control\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    },
+    "11": {
+      "value_convert": "default",
+      "status_code": "control_back_mode",
+      "config_item": {
+        "statusFormat": "{\"control_back_mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"forward\",\"back\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    },
+    "20": {
+      "value_convert": "default",
+      "status_code": "click_control",
+      "config_item": {
+        "statusFormat": "{\"click_control\":\"$\"}",
+        "valueDesc": "{\"range\":[\"up\",\"down\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "xyakonle1azq2xgn"
+      }
+    }
+  },
+  "status_range": {
+    "control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}",
+      "report_type": null
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": "{\"range\":[\"opening\",\"closing\"]}",
+      "report_type": null
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "control_back_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"forward\",\"back\"]}",
+      "report_type": null
+    },
+    "click_control": {
+      "type": "Enum",
+      "value": "{\"range\":[\"up\",\"down\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "control": "stop",
+    "work_state": "opening",
+    "percent_state": 0,
+    "percent_control": 0,
+    "control_back_mode": "forward",
+    "click_control": "up"
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": null,
+  "warnings": null
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

Add a quirk for the Tuya blind motor that clarifies its behavior of reporting `percent_state` as 0 and requires ignoring certain data points for control. Update documentation and include tests for the new quirk.

## Test plan

Tested the quirk implementation to ensure it correctly handles the device's state and control mechanisms.

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

