### PR TITLE
Only apply hw50w7qvxluhslkk quirk to Fahrenheit variants

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -54,6 +54,7 @@ class DatapointDefinition:
     dptype: DPType
     values: str | None = None
     report_type: str | None = None
+    apply_when: Callable[[CustomerDevice], bool] | None = None
 
     def to_function(self) -> DeviceFunction:
         """Convert to DeviceFunction."""
@@ -87,10 +88,19 @@ class DatapointDefinition:
         )
 
 
+@dataclass(kw_only=True)
+class DatapointRemoval:
+    """Marker for a Tuya datapoint removal."""
+
+    apply_when: Callable[[CustomerDevice], bool] | None = None
+
+
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
-    _datapoint_definitions: dict[tuple[int, str], DatapointDefinition | None]
+    _datapoint_definitions: dict[
+        tuple[int, str], DatapointDefinition | DatapointRemoval
+    ]
     _local_strategy: dict[tuple[int, str], LocalConvertStrategy | None]
     _type_information_overrides: dict[
         tuple[int, str], type[TypeInformation[Any]]
@@ -142,33 +152,13 @@ class DeviceQuirk(DeviceQuirkProtocol):
         for key, definition in self._datapoint_definitions.items():
             dpid, dpcode = key
 
-            # Remove definition if explicit None
-            if definition is None:
-                device.function.pop(dpcode, None)
-                device.local_strategy.pop(dpid, None)
-                device.status.pop(dpcode, None)
-                device.status_range.pop(dpcode, None)
+            # Skip definition if its condition is not met on this device
+            if definition.apply_when is not None and not definition.apply_when(
+                device
+            ):
                 continue
 
-            # Add or remove function/status_range attributes
-            if DPMode.READ in definition.dpmode:
-                device.status_range[definition.dpcode] = (
-                    definition.to_status_range()
-                )
-            else:
-                device.status_range.pop(definition.dpcode, None)
-
-            if DPMode.WRITE in definition.dpmode:
-                device.function[definition.dpcode] = definition.to_function()
-            else:
-                device.function.pop(definition.dpcode, None)
-
-            if device.support_local:
-                device.local_strategy[definition.dpid] = (
-                    definition.to_local_strategy(device.product_id)
-                )
-            else:
-                device.local_strategy.pop(definition.dpid, None)
+            self._apply_datapoint_definition(device, dpid, dpcode, definition)
 
         if device.support_local:
             for key, definition in self._local_strategy.items():
@@ -184,6 +174,42 @@ class DeviceQuirk(DeviceQuirkProtocol):
                         device.status_range.get(definition.dpcode),
                     )
                 )
+
+    @staticmethod
+    def _apply_datapoint_definition(
+        device: CustomerDevice,
+        dpid: int,
+        dpcode: str,
+        definition: DatapointDefinition | DatapointRemoval,
+    ) -> None:
+        """Apply a datapoint definition or removal to the device."""
+        # Remove definition if explicit removal
+        if isinstance(definition, DatapointRemoval):
+            device.function.pop(dpcode, None)
+            device.local_strategy.pop(dpid, None)
+            device.status.pop(dpcode, None)
+            device.status_range.pop(dpcode, None)
+            return
+
+        # Add or remove function/status_range attributes
+        if DPMode.READ in definition.dpmode:
+            device.status_range[definition.dpcode] = (
+                definition.to_status_range()
+            )
+        else:
+            device.status_range.pop(definition.dpcode, None)
+
+        if DPMode.WRITE in definition.dpmode:
+            device.function[definition.dpcode] = definition.to_function()
+        else:
+            device.function.pop(definition.dpcode, None)
+
+        if device.support_local:
+            device.local_strategy[definition.dpid] = (
+                definition.to_local_strategy(device.product_id)
+            )
+        else:
+            device.local_strategy.pop(definition.dpid, None)
 
     def applies_to(
         self,
@@ -216,7 +242,13 @@ class DeviceQuirk(DeviceQuirkProtocol):
         registry.register(self._applies_to, self)
 
     def add_dpid_bitmap(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode, label_range: list[str]
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        label_range: list[str],
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Bitmap definition."""
         self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
@@ -225,11 +257,17 @@ class DeviceQuirk(DeviceQuirkProtocol):
             dpmode=dpmode,
             dptype=DPType.BITMAP,
             values=json.dumps({"label": label_range}),
+            apply_when=apply_when,
         )
         return self
 
     def add_dpid_boolean(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Boolean definition."""
         self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
@@ -238,11 +276,18 @@ class DeviceQuirk(DeviceQuirkProtocol):
             dpmode=dpmode,
             dptype=DPType.BOOLEAN,
             values="{}",
+            apply_when=apply_when,
         )
         return self
 
     def add_dpid_enum(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode, enum_range: list[str]
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        enum_range: list[str],
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Enum definition."""
         self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
@@ -251,6 +296,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
             dpmode=dpmode,
             dptype=DPType.ENUM,
             values=json.dumps({"range": enum_range}),
+            apply_when=apply_when,
         )
         return self
 
@@ -266,6 +312,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
         scale: int,
         step: int,
         report_type: str | None = None,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Integer definition."""
         self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
@@ -274,6 +321,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
             dpmode=dpmode,
             dptype=DPType.INTEGER,
             report_type=report_type,
+            apply_when=apply_when,
             values=json.dumps(
                 {
                     "unit": unit,
@@ -297,9 +345,17 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self._type_information_overrides[(dpid, dpcode)] = type_information_cls
         return self
 
-    def remove_dpid(self, *, dpid: int, dpcode: str) -> Self:
+    def remove_dpid(
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
+    ) -> Self:
         """Remove datapoint definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = None
+        self._datapoint_definitions[(dpid, dpcode)] = DatapointRemoval(
+            apply_when=apply_when
+        )
         return self
 
     def set_dpid_strategy_to_enum(

--- a/src/tuya_device_handlers/devices/kt/hw50w7qvxluhslkk.py
+++ b/src/tuya_device_handlers/devices/kt/hw50w7qvxluhslkk.py
@@ -1,13 +1,30 @@
-"""Quirk for Della mini-split (product_id hw50w7qvxluhslkk).
+"""Quirk for Fahrenheit variants of hw50w7qvxluhslkk (eg. Della mini-split).
 
-This quirk forces the temp_set datapoint to advertise a Fahrenheit unit
-so Home Assistant treats it as a Fahrenheit temperature control, and
-removes the redundant temp_set_f datapoint.
+This product_id is shared between regional variants: some units report
+temp_set as 10x the Fahrenheit temperature, others as 10x the Celsius
+temperature (matching the cloud definition). The cloud definition is
+identical for both, but the reported setpoint ranges do not overlap
+(160-310 for Celsius, 610-880 for Fahrenheit), so the current status
+value is used to detect the Fahrenheit variants.
+
+For Fahrenheit variants, this quirk forces the temp_set datapoint to
+advertise a Fahrenheit unit so Home Assistant treats it as a Fahrenheit
+temperature control, and removes the redundant temp_set_f datapoint.
+Celsius variants are left untouched.
 """
+
+from tuya_sharing import CustomerDevice
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.builder import DeviceQuirk
 from tuya_device_handlers.const import DPMode
+
+
+def _is_fahrenheit_variant(device: CustomerDevice) -> bool:
+    """Check if the device reports temp_set in Fahrenheit."""
+    raw_value = device.status.get("temp_set")
+    return isinstance(raw_value, int) and raw_value >= 450
+
 
 (
     DeviceQuirk()
@@ -21,7 +38,12 @@ from tuya_device_handlers.const import DPMode
         max=880,
         scale=1,
         step=5,
+        apply_when=_is_fahrenheit_variant,
     )
-    .remove_dpid(dpid=136, dpcode="temp_set_f")
+    .remove_dpid(
+        dpid=136,
+        dpcode="temp_set_f",
+        apply_when=_is_fahrenheit_variant,
+    )
     .register(TUYA_QUIRKS_REGISTRY)
 )

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -13,6 +13,7 @@ from tuya_sharing import (
 
 from tuya_device_handlers.builder.device_quirk import (
     DatapointDefinition,
+    DatapointRemoval,
     DeviceQuirk,
     LocalConvertStrategy,
 )
@@ -103,7 +104,7 @@ def test_add_dpid_bitmap() -> None:
         dpid=1, dpcode="bm", dpmode=DPMode.READ, label_range=["a", "b"]
     )
     definition = quirk._datapoint_definitions[(1, "bm")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BITMAP
     assert json.loads(definition.values or "")["label"] == ["a", "b"]
 
@@ -114,7 +115,7 @@ def test_add_dpid_boolean() -> None:
         dpid=2, dpcode="bo", dpmode=DPMode.WRITE
     )
     definition = quirk._datapoint_definitions[(2, "bo")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BOOLEAN
 
 
@@ -124,7 +125,7 @@ def test_add_dpid_enum() -> None:
         dpid=3, dpcode="en", dpmode=DPMode.READ, enum_range=["scene", "auto"]
     )
     definition = quirk._datapoint_definitions[(3, "en")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.ENUM
     assert json.loads(definition.values or "")["range"] == ["scene", "auto"]
 
@@ -143,7 +144,7 @@ def test_add_dpid_integer() -> None:
         report_type="sum",
     )
     definition = quirk._datapoint_definitions[(4, "i")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.INTEGER
     assert definition.report_type == "sum"
     payload = json.loads(definition.values or "")
@@ -151,9 +152,11 @@ def test_add_dpid_integer() -> None:
 
 
 def test_remove_dpid() -> None:
-    """remove_dpid stores None to mark the dpid for removal."""
+    """remove_dpid stores a removal marker for the dpid."""
     quirk = DeviceQuirk().remove_dpid(dpid=5, dpcode="rm")
-    assert quirk._datapoint_definitions[(5, "rm")] is None
+    definition = quirk._datapoint_definitions[(5, "rm")]
+    assert isinstance(definition, DatapointRemoval)
+    assert definition.apply_when is None
 
 
 def test_override_category() -> None:
@@ -332,7 +335,7 @@ def test_mqtt_enum_strategy_mapping(
     assert mock_device.status["x"] is False
 
 
-def test_initialise_device_none_definition_removes_everything(
+def test_initialise_device_remove_dpid_removes_everything(
     mock_device: CustomerDevice,
 ) -> None:
     """remove_dpid: function, strategy, status all popped."""
@@ -351,6 +354,65 @@ def test_initialise_device_none_definition_removes_everything(
     assert 7 not in mock_device.local_strategy
     assert "g" not in mock_device.status
     assert "g" not in mock_device.status_range
+
+
+def test_initialise_device_apply_when_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A definition with a met apply_when condition is applied."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    quirk = DeviceQuirk().add_dpid_boolean(
+        dpid=1,
+        dpcode="x",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        apply_when=lambda device: device.status.get("demo_boolean") is True,
+    )
+    quirk.initialise_device(mock_device)
+    assert "x" in mock_device.status_range
+    assert "x" in mock_device.function
+    assert 1 in mock_device.local_strategy
+
+
+def test_initialise_device_apply_when_not_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A definition with an unmet apply_when condition is skipped."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    quirk = DeviceQuirk().add_dpid_boolean(
+        dpid=1,
+        dpcode="x",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        apply_when=lambda device: device.status.get("demo_boolean") is False,
+    )
+    quirk.initialise_device(mock_device)
+    assert "x" not in mock_device.status_range
+    assert "x" not in mock_device.function
+    assert 1 not in mock_device.local_strategy
+
+
+def test_initialise_device_remove_dpid_apply_when_not_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A removal with an unmet apply_when condition is skipped."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {7: {"some": "thing"}}
+    mock_device.function["g"] = DeviceFunction(
+        code="g", type="Boolean", values="{}"
+    )
+    mock_device.status["g"] = True
+    mock_device.status_range["g"] = DeviceStatusRange(
+        code="g", type="Boolean", values="{}"
+    )
+    quirk = DeviceQuirk().remove_dpid(
+        dpid=7, dpcode="g", apply_when=lambda _device: False
+    )
+    quirk.initialise_device(mock_device)
+    assert "g" in mock_device.function
+    assert 7 in mock_device.local_strategy
+    assert "g" in mock_device.status
+    assert "g" in mock_device.status_range
 
 
 def test_initialise_device_override_category(

--- a/tests/devices/kt/test_hw50w7qvxluhslkk.py
+++ b/tests/devices/kt/test_hw50w7qvxluhslkk.py
@@ -8,10 +8,10 @@ from tuya_device_handlers.helpers.homeassistant import TuyaUnitOfTemperature
 from tuya_device_handlers.registry import QuirksRegistry
 
 
-def test_default_definition(
+def test_fahrenheit_variant(
     filled_quirks_registry: QuirksRegistry,
 ) -> None:
-    """Test quirk adds missing datapoints."""
+    """Test quirk fixes the unit on a Fahrenheit variant."""
     device = create_device("kt_hw50w7qvxluhslkk.json")
 
     climate_definition = get_climate_definition(
@@ -33,3 +33,25 @@ def test_default_definition(
     assert set_temperature_wrapper is not None
     assert set_temperature_wrapper.read_device_status(device) == 65
     assert set_temperature_wrapper.native_unit == "℉"
+    assert "temp_set_f" not in device.status_range
+    assert "temp_set_f" not in device.function
+
+
+def test_celsius_variant(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Test quirk leaves a Celsius variant untouched."""
+    device = create_device("kt_hw50w7qvxluhslkk_celsius.json")
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    climate_definition = get_climate_definition(
+        device, TuyaUnitOfTemperature.CELSIUS
+    )
+    assert climate_definition is not None
+    set_temperature_wrapper = climate_definition.set_temperature_wrapper
+    assert set_temperature_wrapper is not None
+    assert set_temperature_wrapper.read_device_status(device) == 26
+    assert set_temperature_wrapper.native_unit == "℃"
+    assert "temp_set_f" in device.status_range
+    assert "temp_set_f" in device.function

--- a/tests/fixtures/devices/kt_hw50w7qvxluhslkk_celsius.json
+++ b/tests/fixtures/devices/kt_hw50w7qvxluhslkk_celsius.json
@@ -1,0 +1,144 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Aire acondicionado",
+  "category": "kt",
+  "product_id": "hw50w7qvxluhslkk",
+  "product_name": "Air conditioner",
+  "online": true,
+  "sub": false,
+  "time_zone": "-03:00",
+  "active_time": "2025-11-14T21:10:07+00:00",
+  "create_time": "2025-11-14T21:10:07+00:00",
+  "update_time": "2025-11-14T21:10:07+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}"
+    },
+    "temp_set_f": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}"
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":-20,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": "un_known"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}",
+      "report_type": null
+    },
+    "humidity_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "temp_set_f": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "temp_set": 260,
+    "temp_current": 29,
+    "mode": "hot",
+    "humidity_current": 0
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "temp_set",
+      "config_item": {
+        "statusFormat": "{\"temp_set\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2103\",\"min\":-20,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "18": {
+      "value_convert": "default",
+      "status_code": "humidity_current",
+      "config_item": {
+        "statusFormat": "{\"humidity_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "136": {
+      "value_convert": "default",
+      "status_code": "temp_set_f",
+      "config_item": {
+        "statusFormat": "{\"temp_set_f\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

The quirk added in #188 forces `temp_set` to Fahrenheit for every device with product_id `hw50w7qvxluhslkk`, but that product_id is shared with Celsius units, so since HA 2026.7 those show wrong setpoints (26 becomes -3.3°C). Discussed in #385.

The cloud definition is identical for both variants, so this PR uses the reported `temp_set` value to tell them apart: Celsius units report 160-310, Fahrenheit units report 610-880. The ranges don't overlap.

To support that, this adds an optional `apply_when` setting on datapoint definitions, as suggested by @epenet in #385. A definition (or removal) with a condition is only applied when the condition is met on the device. The kt quirk now only applies to Fahrenheit variants and leaves Celsius units with their original definition.

## Test plan

- New fixture `kt_hw50w7qvxluhslkk_celsius.json` taken from the diagnostics of my own AC (one of 3 affected units).
- Tests: Fahrenheit fixture still gets the ℉ unit and loses `temp_set_f`, Celsius fixture keeps ℃ and `temp_set_f`, plus builder tests for `apply_when` on definitions and removals.
- Verified on my HAOS 2026.7.1 install with the same logic as a custom quirk in `/config/tuya_quirks/`: the 3 Celsius ACs read and set temperatures correctly.

## Related issue

Fixes #385
