### PR TITLE
Add Celsius variant fixture for hw50w7qvxluhslkk

### DIFF
--- a/tests/devices/kt/test_hw50w7qvxluhslkk.py
+++ b/tests/devices/kt/test_hw50w7qvxluhslkk.py
@@ -33,3 +33,35 @@ def test_default_definition(
     assert set_temperature_wrapper is not None
     assert set_temperature_wrapper.read_device_status(device) == 65
     assert set_temperature_wrapper.native_unit == "℉"
+
+
+def test_celsius_variant_is_forced_to_fahrenheit(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Document the current bug on a Celsius variant of the same product_id.
+
+    This product_id is shared with units that report temp_set in Celsius.
+    The quirk forces the unit to Fahrenheit for all of them, so a Celsius
+    device ends up with the wrong unit (see #385).
+    """
+    device = create_device("kt_hw50w7qvxluhslkk_celsius.json")
+
+    climate_definition = get_climate_definition(
+        device, TuyaUnitOfTemperature.CELSIUS
+    )
+    assert climate_definition is not None
+    set_temperature_wrapper = climate_definition.set_temperature_wrapper
+    assert set_temperature_wrapper is not None
+    assert set_temperature_wrapper.read_device_status(device) == 26
+    assert set_temperature_wrapper.native_unit == "℃"
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    climate_definition = get_climate_definition(
+        device, TuyaUnitOfTemperature.CELSIUS
+    )
+    assert climate_definition is not None
+    set_temperature_wrapper = climate_definition.set_temperature_wrapper
+    assert set_temperature_wrapper is not None
+    # The device reports 26°C, but the quirk relabels it as Fahrenheit.
+    assert set_temperature_wrapper.native_unit == "℉"

--- a/tests/fixtures/devices/kt_hw50w7qvxluhslkk_celsius.json
+++ b/tests/fixtures/devices/kt_hw50w7qvxluhslkk_celsius.json
@@ -1,0 +1,144 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Aire acondicionado",
+  "category": "kt",
+  "product_id": "hw50w7qvxluhslkk",
+  "product_name": "Air conditioner",
+  "online": true,
+  "sub": false,
+  "time_zone": "-03:00",
+  "active_time": "2025-11-14T21:10:07+00:00",
+  "create_time": "2025-11-14T21:10:07+00:00",
+  "update_time": "2025-11-14T21:10:07+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}"
+    },
+    "temp_set_f": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}"
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2103\",\"min\":-20,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": "un_known"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}",
+      "report_type": null
+    },
+    "humidity_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "temp_set_f": {
+      "type": "Integer",
+      "value": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "temp_set": 260,
+    "temp_current": 29,
+    "mode": "hot",
+    "humidity_current": 0
+  },
+  "set_up": true,
+  "support_local": true,
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "temp_set",
+      "config_item": {
+        "statusFormat": "{\"temp_set\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2103\",\"min\":160,\"max\":880,\"scale\":1,\"step\":5}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2103\",\"min\":-20,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"cold\",\"hot\",\"wet\",\"wind\",\"auto\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "18": {
+      "value_convert": "default",
+      "status_code": "humidity_current",
+      "config_item": {
+        "statusFormat": "{\"humidity_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    },
+    "136": {
+      "value_convert": "default",
+      "status_code": "temp_set_f",
+      "config_item": {
+        "statusFormat": "{\"temp_set_f\":\"$\"}",
+        "valueDesc": "{\"unit\":\"\u2109\",\"min\":61,\"max\":88,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "hw50w7qvxluhslkk"
+      }
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

First of three PRs for #385, splitting it as discussed.

This one just adds a fixture for the Celsius variant of `hw50w7qvxluhslkk` (from my own device's diagnostics) and a test that pins the current behavior: the quirk forces the unit to ℉, so a device that reports 26°C ends up labeled as Fahrenheit. The next PRs add the `apply_when` support and make the quirk conditional, and that test will flip to the correct behavior.

## Related issue

#385
