### PR TITLE
Add quirk for Vital+ Ice Bath Pro chiller (ktkzq_urzivdhumrwfakie)

### DIFF
--- a/src/tuya_device_handlers/devices/ktkzq/__init__.py
+++ b/src/tuya_device_handlers/devices/ktkzq/__init__.py
@@ -1,0 +1,4 @@
+"""Quirks for Tuya KTKZQ category (Air conditioner controller).
+
+https://developer.tuya.com/en/docs/iot/f?id=K9gf45ld5l0t9
+"""

--- a/src/tuya_device_handlers/devices/ktkzq/ktkzq_urzivdhumrwfakie.py
+++ b/src/tuya_device_handlers/devices/ktkzq/ktkzq_urzivdhumrwfakie.py
@@ -1,0 +1,53 @@
+"""Quirk for Vital+ Ice Bath Pro chiller (product_id urzivdhumrwfakie).
+
+The Tuya cloud reports this device as category 'ktkzq' (Air conditioner controller)
+which HA has no entity mappings for. This quirk overrides the category to 'wk'
+(thermostat) so HA creates climate + switch entities from the existing dpcodes.
+
+Data points:
+  DP 2   temp_set      Integer  3-45°C (scale 0)  - target temperature
+  DP 3   temp_current  Integer  -40 to 100°C (scale 1) - current water temp
+  DP 7   child_lock    Boolean  - child lock
+  DP 108 power_switch  Boolean  - chiller on/off (mapped to 'switch' for climate)
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="urzivdhumrwfakie",
+        manufacturer="Vital+",
+        model="Ice Bath Pro",
+    )
+    .override_category("wk")
+    # DP 2: temp_set (already in function/status_range, but ensure it's writable)
+    .add_dpid_integer(
+        dpid=2,
+        dpcode="temp_set",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="℃", min=3, max=45, scale=0, step=1,
+    )
+    # DP 3: temp_current (read-only, scale 1 means divide by 10)
+    .add_dpid_integer(
+        dpid=3,
+        dpcode="temp_current",
+        dpmode=DPMode.READ,
+        unit="℃", min=-400, max=1000, scale=1, step=1,
+    )
+    # DP 7: child_lock (read/write boolean)
+    .add_dpid_boolean(
+        dpid=7,
+        dpcode="child_lock",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    # DP 108: power_switch -> mapped as 'switch' so climate entity has on/off
+    .add_dpid_boolean(
+        dpid=108,
+        dpcode="switch",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/ktkzq/__init__.py
+++ b/tests/devices/ktkzq/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya KTKZQ category quirks."""

--- a/tests/devices/ktkzq/test_urzivdhumrwfakie.py
+++ b/tests/devices/ktkzq/test_urzivdhumrwfakie.py
@@ -1,0 +1,44 @@
+"""Test device-level quirk initialisation."""
+
+from tests import create_device
+from tuya_device_handlers.definition.climate import get_default_definition
+from tuya_device_handlers.helpers.homeassistant import TuyaUnitOfTemperature
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Test quirk."""
+    device = create_device("ktkzq_urzivdhumrwfakie.json")
+
+    # Before quirk: category is ktkzq, no climate definition
+    assert device.category == "ktkzq"
+    assert "temp_set" in device.function
+    assert "temp_current" in device.status_range
+    assert "child_lock" in device.function
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    # After quirk: category should be overridden to wk
+    assert device.category == "wk"
+
+    # Check climate definition
+    definition = get_default_definition(device, TuyaUnitOfTemperature.CELSIUS)
+    assert definition is not None
+    assert definition.current_temperature_wrapper is not None
+    assert definition.set_temperature_wrapper is not None
+    assert definition.switch_wrapper is not None
+    assert definition.hvac_mode_wrapper is None  # No mode dpcode
+
+    # Check that temp_set is writable
+    assert "temp_set" in device.function
+    assert "temp_set" in device.status_range
+
+    # Check that child_lock is present
+    assert "child_lock" in device.function
+    assert "child_lock" in device.status_range
+
+    # Check that switch (power_switch) is present
+    assert "switch" in device.function
+    assert "switch" in device.status_range

--- a/tests/fixtures/devices/ktkzq_urzivdhumrwfakie.json
+++ b/tests/fixtures/devices/ktkzq_urzivdhumrwfakie.json
@@ -1,0 +1,87 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "VITAL+",
+  "category": "ktkzq",
+  "product_id": "urzivdhumrwfakie",
+  "product_name": "VITAL+",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2026-07-16T10:14:21+00:00",
+  "create_time": "2026-07-16T10:14:21+00:00",
+  "update_time": "2026-07-16T10:14:21+00:00",
+  "function": {
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":3,\"max\":45,\"scale\":0,\"step\":1}"
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}"
+    }
+  },
+  "local_strategy": {
+    "2": {
+      "value_convert": "default",
+      "status_code": "temp_set",
+      "config_item": {
+        "statusFormat": "{\"temp_set\":\"$\"}",
+        "valueDesc": "{\"unit\":\"℃\",\"min\":3,\"max\":45,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "urzivdhumrwfakie"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\":\"$\"}",
+        "valueDesc": "{\"unit\":\"℃\",\"min\":-400,\"max\":1000,\"scale\":1,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "urzivdhumrwfakie"
+      }
+    },
+    "7": {
+      "value_convert": "default",
+      "status_code": "child_lock",
+      "config_item": {
+        "statusFormat": "{\"child_lock\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "urzivdhumrwfakie"
+      }
+    }
+  },
+  "status_range": {
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":3,\"max\":45,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\":\"℃\",\"min\":-400,\"max\":1000,\"scale\":1,\"step\":1}",
+      "report_type": "un_known"
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "temp_set": 13,
+    "temp_current": 48,
+    "child_lock": true
+  },
+  "set_up": false,
+  "support_local": true,
+  "quirk": null,
+  "warnings": null
+}


### PR DESCRIPTION
## Summary

Adds a device quirk for the **Vital+ Ice Bath Pro** chiller (product_id: `urzivdhumrwfakie`).

The Tuya cloud reports this device as category `ktkzq` (Air conditioner controller) which HA has no entity mappings for. This quirk overrides the category to `wk` (thermostat) so HA creates climate + switch entities from the existing dpcodes.

## Data Points

| DP | Code | Type | Details |
|----|------|------|---------|
| 2 | `temp_set` | Integer | 3-45°C, scale 0, step 1 |
| 3 | `temp_current` | Integer | -40 to 100°C, scale 1, step 1 |
| 7 | `child_lock` | Boolean | Child lock |
| 108 | `power_switch` | Boolean | Chiller on/off (mapped to `switch` for climate) |

## Device Details

- **Product ID:** urzivdhumrwfakie
- **Manufacturer:** Vital+
- **Model:** Ice Bath Pro
- **Category:** ktkzq (Tuya Air conditioner controller)

## What This Quirk Does

1. Overrides the device category from `ktkzq` to `wk` (thermostat)
2. Ensures `temp_set` (DP 2) is properly configured as writable
3. Ensures `temp_current` (DP 3) is properly configured as read-only with correct scale
4. Maps `power_switch` (DP 108) to the `switch` dpcode so the climate entity has on/off control

## Testing

- [x] Test passes: `pytest tests/devices/ktkzq/test_urzivdhumrwfakie.py`
- [x] Verified working on actual hardware: climate entity created with current temp (6.4°C), target temp (13°C), and on/off control

## Related Issues

Fixes #276