### PR TITLE
Allow datapoint definitions to apply conditionally

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -1,5 +1,6 @@
 """Base quirk definition."""
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 import inspect
@@ -45,7 +46,7 @@ class LocalConvertStrategy:
 
 
 @dataclass(kw_only=True)
-class DatapointBase:
+class DatapointBase(ABC):
     """Base for a Tuya datapoint entry.
 
     When `apply_when` is set, the entry is only applied to devices for
@@ -61,10 +62,21 @@ class DatapointBase:
         """Check whether this entry applies to the device."""
         return self.apply_when is None or self.apply_when(device)
 
+    @abstractmethod
+    def apply(self, device: CustomerDevice) -> None:
+        """Apply this entry to the device."""
+
 
 @dataclass(kw_only=True)
 class DatapointRemoval(DatapointBase):
     """Removal of a Tuya datapoint."""
+
+    def apply(self, device: CustomerDevice) -> None:
+        """Remove the datapoint from the device."""
+        device.function.pop(self.dpcode, None)
+        device.local_strategy.pop(self.dpid, None)
+        device.status.pop(self.dpcode, None)
+        device.status_range.pop(self.dpcode, None)
 
 
 @dataclass(kw_only=True)
@@ -75,6 +87,25 @@ class DatapointDefinition(DatapointBase):
     dptype: DPType
     values: str | None = None
     report_type: str | None = None
+
+    def apply(self, device: CustomerDevice) -> None:
+        """Add or update the datapoint on the device."""
+        if DPMode.READ in self.dpmode:
+            device.status_range[self.dpcode] = self.to_status_range()
+        else:
+            device.status_range.pop(self.dpcode, None)
+
+        if DPMode.WRITE in self.dpmode:
+            device.function[self.dpcode] = self.to_function()
+        else:
+            device.function.pop(self.dpcode, None)
+
+        if device.support_local:
+            device.local_strategy[self.dpid] = self.to_local_strategy(
+                device.product_id
+            )
+        else:
+            device.local_strategy.pop(self.dpid, None)
 
     def to_function(self) -> DeviceFunction:
         """Convert to DeviceFunction."""
@@ -162,7 +193,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
         for definition in self._datapoint_definitions:
             if definition.applies_to_device(device):
-                self._apply_datapoint(device, definition)
+                definition.apply(device)
 
         if device.support_local:
             for key, definition in self._local_strategy.items():
@@ -178,41 +209,6 @@ class DeviceQuirk(DeviceQuirkProtocol):
                         device.status_range.get(definition.dpcode),
                     )
                 )
-
-    @staticmethod
-    def _apply_datapoint(
-        device: CustomerDevice, definition: DatapointBase
-    ) -> None:
-        """Apply a single datapoint entry to the device."""
-        if isinstance(definition, DatapointRemoval):
-            device.function.pop(definition.dpcode, None)
-            device.local_strategy.pop(definition.dpid, None)
-            device.status.pop(definition.dpcode, None)
-            device.status_range.pop(definition.dpcode, None)
-            return
-
-        if TYPE_CHECKING:
-            assert isinstance(definition, DatapointDefinition)
-
-        # Add or remove function/status_range attributes
-        if DPMode.READ in definition.dpmode:
-            device.status_range[definition.dpcode] = (
-                definition.to_status_range()
-            )
-        else:
-            device.status_range.pop(definition.dpcode, None)
-
-        if DPMode.WRITE in definition.dpmode:
-            device.function[definition.dpcode] = definition.to_function()
-        else:
-            device.function.pop(definition.dpcode, None)
-
-        if device.support_local:
-            device.local_strategy[definition.dpid] = (
-                definition.to_local_strategy(device.product_id)
-            )
-        else:
-            device.local_strategy.pop(definition.dpid, None)
 
     def applies_to(
         self,

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -45,11 +45,22 @@ class LocalConvertStrategy:
 
 
 @dataclass(kw_only=True)
-class DatapointDefinition:
-    """Definition for a Tuya datapoint."""
+class DatapointBase:
+    """Base for a Tuya datapoint entry."""
 
     dpid: int
     dpcode: str
+
+
+@dataclass(kw_only=True)
+class DatapointRemoval(DatapointBase):
+    """Removal of a Tuya datapoint."""
+
+
+@dataclass(kw_only=True)
+class DatapointDefinition(DatapointBase):
+    """Definition for a Tuya datapoint."""
+
     dpmode: DPMode
     dptype: DPType
     values: str | None = None
@@ -90,7 +101,9 @@ class DatapointDefinition:
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
-    _datapoint_definitions: dict[tuple[int, str], DatapointDefinition | None]
+    _datapoint_definitions: dict[
+        tuple[int, str], DatapointDefinition | DatapointRemoval
+    ]
     _local_strategy: dict[tuple[int, str], LocalConvertStrategy | None]
     _type_information_overrides: dict[
         tuple[int, str], type[TypeInformation[Any]]
@@ -142,8 +155,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
         for key, definition in self._datapoint_definitions.items():
             dpid, dpcode = key
 
-            # Remove definition if explicit None
-            if definition is None:
+            # Remove definition if explicit removal
+            if isinstance(definition, DatapointRemoval):
                 device.function.pop(dpcode, None)
                 device.local_strategy.pop(dpid, None)
                 device.status.pop(dpcode, None)
@@ -299,7 +312,9 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     def remove_dpid(self, *, dpid: int, dpcode: str) -> Self:
         """Remove datapoint definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = None
+        self._datapoint_definitions[(dpid, dpcode)] = DatapointRemoval(
+            dpid=dpid, dpcode=dpcode
+        )
         return self
 
     def set_dpid_strategy_to_enum(

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -101,9 +101,7 @@ class DatapointDefinition(DatapointBase):
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
-    _datapoint_definitions: dict[
-        tuple[int, str], DatapointDefinition | DatapointRemoval
-    ]
+    _datapoint_definitions: list[DatapointDefinition | DatapointRemoval]
     _local_strategy: dict[tuple[int, str], LocalConvertStrategy | None]
     _type_information_overrides: dict[
         tuple[int, str], type[TypeInformation[Any]]
@@ -118,7 +116,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self._applies_to: str | None = None
         self._override_category: str | None = None
 
-        self._datapoint_definitions = {}
+        self._datapoint_definitions = []
         self._local_strategy = {}
         self._type_information_overrides = {}
         self._get_wrapper_functions = {}
@@ -152,40 +150,12 @@ class DeviceQuirk(DeviceQuirkProtocol):
         if self._override_category is not None:
             device.category = self._override_category
 
-        for key, definition in self._datapoint_definitions.items():
-            dpid, dpcode = key
-
-            # Remove definition if explicit removal
-            if isinstance(definition, DatapointRemoval):
-                device.function.pop(dpcode, None)
-                device.local_strategy.pop(dpid, None)
-                device.status.pop(dpcode, None)
-                device.status_range.pop(dpcode, None)
-                continue
-
-            # Add or remove function/status_range attributes
-            if DPMode.READ in definition.dpmode:
-                device.status_range[definition.dpcode] = (
-                    definition.to_status_range()
-                )
-            else:
-                device.status_range.pop(definition.dpcode, None)
-
-            if DPMode.WRITE in definition.dpmode:
-                device.function[definition.dpcode] = definition.to_function()
-            else:
-                device.function.pop(definition.dpcode, None)
-
-            if device.support_local:
-                device.local_strategy[definition.dpid] = (
-                    definition.to_local_strategy(device.product_id)
-                )
-            else:
-                device.local_strategy.pop(definition.dpid, None)
+        for definition in self._datapoint_definitions:
+            self._apply_datapoint(device, definition)
 
         if device.support_local:
             for key, definition in self._local_strategy.items():
-                dpid, dpcode = key
+                dpid, _dpcode = key
 
                 if definition is None:
                     device.local_strategy.pop(dpid, None)
@@ -197,6 +167,40 @@ class DeviceQuirk(DeviceQuirkProtocol):
                         device.status_range.get(definition.dpcode),
                     )
                 )
+
+    @staticmethod
+    def _apply_datapoint(
+        device: CustomerDevice,
+        definition: DatapointDefinition | DatapointRemoval,
+    ) -> None:
+        """Apply a single datapoint entry to the device."""
+        # Remove definition if explicit removal
+        if isinstance(definition, DatapointRemoval):
+            device.function.pop(definition.dpcode, None)
+            device.local_strategy.pop(definition.dpid, None)
+            device.status.pop(definition.dpcode, None)
+            device.status_range.pop(definition.dpcode, None)
+            return
+
+        # Add or remove function/status_range attributes
+        if DPMode.READ in definition.dpmode:
+            device.status_range[definition.dpcode] = (
+                definition.to_status_range()
+            )
+        else:
+            device.status_range.pop(definition.dpcode, None)
+
+        if DPMode.WRITE in definition.dpmode:
+            device.function[definition.dpcode] = definition.to_function()
+        else:
+            device.function.pop(definition.dpcode, None)
+
+        if device.support_local:
+            device.local_strategy[definition.dpid] = (
+                definition.to_local_strategy(device.product_id)
+            )
+        else:
+            device.local_strategy.pop(definition.dpid, None)
 
     def applies_to(
         self,
@@ -232,12 +236,14 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self, *, dpid: int, dpcode: str, dpmode: DPMode, label_range: list[str]
     ) -> Self:
         """Add datapoint Bitmap definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
-            dpid=dpid,
-            dpcode=dpcode,
-            dpmode=dpmode,
-            dptype=DPType.BITMAP,
-            values=json.dumps({"label": label_range}),
+        self._datapoint_definitions.append(
+            DatapointDefinition(
+                dpid=dpid,
+                dpcode=dpcode,
+                dpmode=dpmode,
+                dptype=DPType.BITMAP,
+                values=json.dumps({"label": label_range}),
+            )
         )
         return self
 
@@ -245,12 +251,14 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self, *, dpid: int, dpcode: str, dpmode: DPMode
     ) -> Self:
         """Add datapoint Boolean definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
-            dpid=dpid,
-            dpcode=dpcode,
-            dpmode=dpmode,
-            dptype=DPType.BOOLEAN,
-            values="{}",
+        self._datapoint_definitions.append(
+            DatapointDefinition(
+                dpid=dpid,
+                dpcode=dpcode,
+                dpmode=dpmode,
+                dptype=DPType.BOOLEAN,
+                values="{}",
+            )
         )
         return self
 
@@ -258,12 +266,14 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self, *, dpid: int, dpcode: str, dpmode: DPMode, enum_range: list[str]
     ) -> Self:
         """Add datapoint Enum definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
-            dpid=dpid,
-            dpcode=dpcode,
-            dpmode=dpmode,
-            dptype=DPType.ENUM,
-            values=json.dumps({"range": enum_range}),
+        self._datapoint_definitions.append(
+            DatapointDefinition(
+                dpid=dpid,
+                dpcode=dpcode,
+                dpmode=dpmode,
+                dptype=DPType.ENUM,
+                values=json.dumps({"range": enum_range}),
+            )
         )
         return self
 
@@ -281,21 +291,23 @@ class DeviceQuirk(DeviceQuirkProtocol):
         report_type: str | None = None,
     ) -> Self:
         """Add datapoint Integer definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = DatapointDefinition(
-            dpid=dpid,
-            dpcode=dpcode,
-            dpmode=dpmode,
-            dptype=DPType.INTEGER,
-            report_type=report_type,
-            values=json.dumps(
-                {
-                    "unit": unit,
-                    "min": min,
-                    "max": max,
-                    "scale": scale,
-                    "step": step,
-                }
-            ),
+        self._datapoint_definitions.append(
+            DatapointDefinition(
+                dpid=dpid,
+                dpcode=dpcode,
+                dpmode=dpmode,
+                dptype=DPType.INTEGER,
+                report_type=report_type,
+                values=json.dumps(
+                    {
+                        "unit": unit,
+                        "min": min,
+                        "max": max,
+                        "scale": scale,
+                        "step": step,
+                    }
+                ),
+            )
         )
         return self
 
@@ -312,8 +324,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     def remove_dpid(self, *, dpid: int, dpcode: str) -> Self:
         """Remove datapoint definition."""
-        self._datapoint_definitions[(dpid, dpcode)] = DatapointRemoval(
-            dpid=dpid, dpcode=dpcode
+        self._datapoint_definitions.append(
+            DatapointRemoval(dpid=dpid, dpcode=dpcode)
         )
         return self
 

--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -46,10 +46,20 @@ class LocalConvertStrategy:
 
 @dataclass(kw_only=True)
 class DatapointBase:
-    """Base for a Tuya datapoint entry."""
+    """Base for a Tuya datapoint entry.
+
+    When `apply_when` is set, the entry is only applied to devices for
+    which the callable returns True. This allows a quirk to cover
+    variants that share a product_id but behave differently.
+    """
 
     dpid: int
     dpcode: str
+    apply_when: Callable[[CustomerDevice], bool] | None = None
+
+    def applies_to_device(self, device: CustomerDevice) -> bool:
+        """Check whether this entry applies to the device."""
+        return self.apply_when is None or self.apply_when(device)
 
 
 @dataclass(kw_only=True)
@@ -101,7 +111,7 @@ class DatapointDefinition(DatapointBase):
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
-    _datapoint_definitions: list[DatapointDefinition | DatapointRemoval]
+    _datapoint_definitions: list[DatapointBase]
     _local_strategy: dict[tuple[int, str], LocalConvertStrategy | None]
     _type_information_overrides: dict[
         tuple[int, str], type[TypeInformation[Any]]
@@ -151,7 +161,8 @@ class DeviceQuirk(DeviceQuirkProtocol):
             device.category = self._override_category
 
         for definition in self._datapoint_definitions:
-            self._apply_datapoint(device, definition)
+            if definition.applies_to_device(device):
+                self._apply_datapoint(device, definition)
 
         if device.support_local:
             for key, definition in self._local_strategy.items():
@@ -170,17 +181,18 @@ class DeviceQuirk(DeviceQuirkProtocol):
 
     @staticmethod
     def _apply_datapoint(
-        device: CustomerDevice,
-        definition: DatapointDefinition | DatapointRemoval,
+        device: CustomerDevice, definition: DatapointBase
     ) -> None:
         """Apply a single datapoint entry to the device."""
-        # Remove definition if explicit removal
         if isinstance(definition, DatapointRemoval):
             device.function.pop(definition.dpcode, None)
             device.local_strategy.pop(definition.dpid, None)
             device.status.pop(definition.dpcode, None)
             device.status_range.pop(definition.dpcode, None)
             return
+
+        if TYPE_CHECKING:
+            assert isinstance(definition, DatapointDefinition)
 
         # Add or remove function/status_range attributes
         if DPMode.READ in definition.dpmode:
@@ -233,7 +245,13 @@ class DeviceQuirk(DeviceQuirkProtocol):
         registry.register(self._applies_to, self)
 
     def add_dpid_bitmap(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode, label_range: list[str]
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        label_range: list[str],
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Bitmap definition."""
         self._datapoint_definitions.append(
@@ -243,12 +261,18 @@ class DeviceQuirk(DeviceQuirkProtocol):
                 dpmode=dpmode,
                 dptype=DPType.BITMAP,
                 values=json.dumps({"label": label_range}),
+                apply_when=apply_when,
             )
         )
         return self
 
     def add_dpid_boolean(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Boolean definition."""
         self._datapoint_definitions.append(
@@ -258,12 +282,19 @@ class DeviceQuirk(DeviceQuirkProtocol):
                 dpmode=dpmode,
                 dptype=DPType.BOOLEAN,
                 values="{}",
+                apply_when=apply_when,
             )
         )
         return self
 
     def add_dpid_enum(
-        self, *, dpid: int, dpcode: str, dpmode: DPMode, enum_range: list[str]
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        dpmode: DPMode,
+        enum_range: list[str],
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Enum definition."""
         self._datapoint_definitions.append(
@@ -273,6 +304,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
                 dpmode=dpmode,
                 dptype=DPType.ENUM,
                 values=json.dumps({"range": enum_range}),
+                apply_when=apply_when,
             )
         )
         return self
@@ -289,6 +321,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
         scale: int,
         step: int,
         report_type: str | None = None,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
     ) -> Self:
         """Add datapoint Integer definition."""
         self._datapoint_definitions.append(
@@ -307,6 +340,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
                         "step": step,
                     }
                 ),
+                apply_when=apply_when,
             )
         )
         return self
@@ -322,10 +356,16 @@ class DeviceQuirk(DeviceQuirkProtocol):
         self._type_information_overrides[(dpid, dpcode)] = type_information_cls
         return self
 
-    def remove_dpid(self, *, dpid: int, dpcode: str) -> Self:
+    def remove_dpid(
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
+    ) -> Self:
         """Remove datapoint definition."""
         self._datapoint_definitions.append(
-            DatapointRemoval(dpid=dpid, dpcode=dpcode)
+            DatapointRemoval(dpid=dpid, dpcode=dpcode, apply_when=apply_when)
         )
         return self
 

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -13,6 +13,7 @@ from tuya_sharing import (
 
 from tuya_device_handlers.builder.device_quirk import (
     DatapointDefinition,
+    DatapointRemoval,
     DeviceQuirk,
     LocalConvertStrategy,
 )
@@ -103,7 +104,7 @@ def test_add_dpid_bitmap() -> None:
         dpid=1, dpcode="bm", dpmode=DPMode.READ, label_range=["a", "b"]
     )
     definition = quirk._datapoint_definitions[(1, "bm")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BITMAP
     assert json.loads(definition.values or "")["label"] == ["a", "b"]
 
@@ -114,7 +115,7 @@ def test_add_dpid_boolean() -> None:
         dpid=2, dpcode="bo", dpmode=DPMode.WRITE
     )
     definition = quirk._datapoint_definitions[(2, "bo")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BOOLEAN
 
 
@@ -124,7 +125,7 @@ def test_add_dpid_enum() -> None:
         dpid=3, dpcode="en", dpmode=DPMode.READ, enum_range=["scene", "auto"]
     )
     definition = quirk._datapoint_definitions[(3, "en")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.ENUM
     assert json.loads(definition.values or "")["range"] == ["scene", "auto"]
 
@@ -143,7 +144,7 @@ def test_add_dpid_integer() -> None:
         report_type="sum",
     )
     definition = quirk._datapoint_definitions[(4, "i")]
-    assert definition is not None
+    assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.INTEGER
     assert definition.report_type == "sum"
     payload = json.loads(definition.values or "")
@@ -151,9 +152,12 @@ def test_add_dpid_integer() -> None:
 
 
 def test_remove_dpid() -> None:
-    """remove_dpid stores None to mark the dpid for removal."""
+    """remove_dpid stores a removal entry for the dpid."""
     quirk = DeviceQuirk().remove_dpid(dpid=5, dpcode="rm")
-    assert quirk._datapoint_definitions[(5, "rm")] is None
+    entry = quirk._datapoint_definitions[(5, "rm")]
+    assert isinstance(entry, DatapointRemoval)
+    assert entry.dpid == 5
+    assert entry.dpcode == "rm"
 
 
 def test_override_category() -> None:
@@ -332,7 +336,7 @@ def test_mqtt_enum_strategy_mapping(
     assert mock_device.status["x"] is False
 
 
-def test_initialise_device_none_definition_removes_everything(
+def test_initialise_device_remove_dpid_removes_everything(
     mock_device: CustomerDevice,
 ) -> None:
     """remove_dpid: function, strategy, status all popped."""

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -357,6 +357,101 @@ def test_initialise_device_remove_dpid_removes_everything(
     assert "g" not in mock_device.status_range
 
 
+def test_initialise_device_apply_when_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A definition whose apply_when returns True is applied."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    quirk = DeviceQuirk().add_dpid_boolean(
+        dpid=1,
+        dpcode="x",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        apply_when=lambda device: device.status.get("demo_boolean") is True,
+    )
+    quirk.initialise_device(mock_device)
+    assert "x" in mock_device.status_range
+    assert "x" in mock_device.function
+    assert 1 in mock_device.local_strategy
+
+
+def test_initialise_device_apply_when_not_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A definition whose apply_when returns False is skipped."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    quirk = DeviceQuirk().add_dpid_boolean(
+        dpid=1,
+        dpcode="x",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        apply_when=lambda device: device.status.get("demo_boolean") is False,
+    )
+    quirk.initialise_device(mock_device)
+    assert "x" not in mock_device.status_range
+    assert "x" not in mock_device.function
+    assert 1 not in mock_device.local_strategy
+
+
+def test_initialise_device_remove_dpid_apply_when_not_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A removal whose apply_when returns False is skipped."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {7: {"some": "thing"}}
+    mock_device.function["g"] = DeviceFunction(
+        code="g", type="Boolean", values="{}"
+    )
+    mock_device.status["g"] = True
+    mock_device.status_range["g"] = DeviceStatusRange(
+        code="g", type="Boolean", values="{}"
+    )
+    quirk = DeviceQuirk().remove_dpid(
+        dpid=7, dpcode="g", apply_when=lambda _device: False
+    )
+    quirk.initialise_device(mock_device)
+    assert "g" in mock_device.function
+    assert 7 in mock_device.local_strategy
+    assert "g" in mock_device.status
+    assert "g" in mock_device.status_range
+
+
+def test_initialise_device_apply_when_variants(
+    mock_device: CustomerDevice,
+) -> None:
+    """Two conditional definitions can target the same datapoint."""
+    mock_device.support_local = True
+    mock_device.local_strategy = {}
+    quirk = (
+        DeviceQuirk()
+        .add_dpid_integer(
+            dpid=1,
+            dpcode="x",
+            dpmode=DPMode.READ,
+            unit="℃",
+            min=0,
+            max=100,
+            scale=0,
+            step=1,
+            apply_when=lambda device: device.status.get("demo_integer") == 123,
+        )
+        .add_dpid_integer(
+            dpid=1,
+            dpcode="x",
+            dpmode=DPMode.READ,
+            unit="℉",
+            min=0,
+            max=100,
+            scale=0,
+            step=1,
+            apply_when=lambda device: device.status.get("demo_integer") != 123,
+        )
+    )
+    quirk.initialise_device(mock_device)
+    values = mock_device.status_range["x"].values
+    assert json.loads(values or "")["unit"] == "℃"
+
+
 def test_initialise_device_override_category(
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -103,7 +103,7 @@ def test_add_dpid_bitmap() -> None:
     quirk = DeviceQuirk().add_dpid_bitmap(
         dpid=1, dpcode="bm", dpmode=DPMode.READ, label_range=["a", "b"]
     )
-    definition = quirk._datapoint_definitions[(1, "bm")]
+    definition = quirk._datapoint_definitions[0]
     assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BITMAP
     assert json.loads(definition.values or "")["label"] == ["a", "b"]
@@ -114,7 +114,7 @@ def test_add_dpid_boolean() -> None:
     quirk = DeviceQuirk().add_dpid_boolean(
         dpid=2, dpcode="bo", dpmode=DPMode.WRITE
     )
-    definition = quirk._datapoint_definitions[(2, "bo")]
+    definition = quirk._datapoint_definitions[0]
     assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.BOOLEAN
 
@@ -124,7 +124,7 @@ def test_add_dpid_enum() -> None:
     quirk = DeviceQuirk().add_dpid_enum(
         dpid=3, dpcode="en", dpmode=DPMode.READ, enum_range=["scene", "auto"]
     )
-    definition = quirk._datapoint_definitions[(3, "en")]
+    definition = quirk._datapoint_definitions[0]
     assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.ENUM
     assert json.loads(definition.values or "")["range"] == ["scene", "auto"]
@@ -143,7 +143,7 @@ def test_add_dpid_integer() -> None:
         step=1,
         report_type="sum",
     )
-    definition = quirk._datapoint_definitions[(4, "i")]
+    definition = quirk._datapoint_definitions[0]
     assert isinstance(definition, DatapointDefinition)
     assert definition.dptype is DPType.INTEGER
     assert definition.report_type == "sum"
@@ -154,7 +154,7 @@ def test_add_dpid_integer() -> None:
 def test_remove_dpid() -> None:
     """remove_dpid stores a removal entry for the dpid."""
     quirk = DeviceQuirk().remove_dpid(dpid=5, dpcode="rm")
-    entry = quirk._datapoint_definitions[(5, "rm")]
+    entry = quirk._datapoint_definitions[0]
     assert isinstance(entry, DatapointRemoval)
     assert entry.dpid == 5
     assert entry.dpcode == "rm"


### PR DESCRIPTION
## Summary

Second of the three PRs for #385.

This adds an optional `apply_when` callback to the datapoint builder methods. When set, that definition (or removal) is only applied to devices for which the callback returns True, so a single quirk can cover variants that share a product_id but behave differently.

No behavior change for existing quirks. The kt quirk that actually uses this comes in the next PR.

## Related issue

#385
