### PR TITLE
Add the Open Home Foundation AI Policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -103,3 +103,10 @@ This will allow a chance to talk it over with the owners and validate your appro
 <!-- github-only -->
 
 [code of conduct]: CODE_OF_CONDUCT.md
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](../AI_POLICY.md). In
+short: AI tools are welcome as an aid, but you must fully understand and be
+able to explain every change you submit. Contributions made by autonomous
+agents are not accepted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,3 +124,11 @@ with open(name, 'w') as f:
 print(name)
 "
 ```
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](AI_POLICY.md).
+Autonomous contributions are not accepted: a human must review, understand,
+and be able to explain every change before it is submitted. Do not open
+issues or pull requests autonomously, and do not post comments on behalf of
+a user without their review.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,45 @@
+# Open Home Foundation - AI Policy
+
+We support using AI (i.e., LLMs) as tools when contributing to Open Home Foundation projects. However, you are responsible for any contributions you submit, and we are responsible for any contributions we merge and release. We hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions. Submitting AI-generated content that you have not personally reviewed and understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to be used for contributing to our projects.** We will close any pull requests or issues that we believe were created autonomously, and may mark automated comments as spam. This includes contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+We don't mind if you use AI tools to help you write. However, do not have tools post unreviewed content on your behalf. Keep responses to the minimum needed to communicate your intent. We may hide any comments that we believe are unreviewed AI output.
+
+If you are opening a pull request, we expect you to be able to explain the proposed changes in your own words. This includes the pull request description and responses to questions. If you use AI to help generate the pull request summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You should understand and be able to explain your own work. Using AI to improve grammar or clarity is fine, but the substance of your responses must be your own.
+
+If you wish to include context from an interaction with AI in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. It must be accompanied by your own commentary explaining the relevance and implications of the context. Do not share long snippets.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating as a non-native English speaker. Using AI to improve the grammar or clarity of text you have written yourself is fine. If you are using AI to translate your comments, please ensure the translation accurately reflects your intent. Including your original text in a details block shows the effort behind your contribution, helps maintainers verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, due to the foundational open source nature of our projects, we require a human in the loop who understands the work produced by AI.
+
+All contributions must be reviewed and understood by the contributor before submission. You should be able to explain every change in a pull request you submit. Pull requests that appear to be unreviewed AI output will be closed without review.
+
+## Our use of AI
+
+Some of our projects use AI tools to assist with code reviews, issue triaging, reporting, and other project management tasks. These tools may leave comments on pull requests or issues. As with any automated tooling, these comments are not always correct.
+
+If an AI tool leaves a comment on your contribution, treat it as you would any other review comment. If you believe it is incorrect, say so; a brief explanation is sufficient. Maintainers always have the final say. If in doubt, ask a maintainer.
+
+## Enforcement
+
+Contributions that do not follow this policy will be closed. Repeated violations may result in being blocked from contributing to OHF projects. If you believe your contribution was closed in error, you are welcome to reach out to a maintainer to discuss.
+
+---
+
+The canonical version of this policy is published at
+<https://developers.home-assistant.io/docs/ai_policy>. In case of differences,
+the published version applies.


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Adds the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy) to this repository. This is part of a rollout across all repositories in the `home-assistant` and `home-assistant-libs` organizations, announced in [this blog post](https://developers.home-assistant.io/blog/2026/07/20/ai-policy/).

- Adds `AI_POLICY.md` to the repository root.
- Adds a reference to the policy in `.github/CONTRIBUTING.md`.
- Adds a reference to the policy in `AGENTS.md`, which `CLAUDE.md` symlinks to.

The policy describes how we handle AI-assisted contributions: AI tools are welcome as an aid, but contributors must fully understand and be able to explain every change they submit, and contributions made by autonomous agents are not accepted. The canonical version lives in our [developer documentation](https://developers.home-assistant.io/docs/ai_policy).

## Test plan

<!-- How was it tested? -->

Documentation-only change. Verified the added Markdown links resolve to `AI_POLICY.md` within the repository.

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

None. This is a policy rollout, not tied to a specific issue.
