### PR TITLE
Only apply hw50w7qvxluhslkk quirk to Fahrenheit variants

### DIFF
--- a/src/tuya_device_handlers/devices/kt/hw50w7qvxluhslkk.py
+++ b/src/tuya_device_handlers/devices/kt/hw50w7qvxluhslkk.py
@@ -1,13 +1,30 @@
-"""Quirk for Della mini-split (product_id hw50w7qvxluhslkk).
+"""Quirk for Fahrenheit variants of hw50w7qvxluhslkk (eg. Della mini-split).
 
-This quirk forces the temp_set datapoint to advertise a Fahrenheit unit
-so Home Assistant treats it as a Fahrenheit temperature control, and
-removes the redundant temp_set_f datapoint.
+This product_id is shared between regional variants: some units report
+temp_set as 10x the Fahrenheit temperature, others as 10x the Celsius
+temperature (matching the cloud definition). The cloud definition is
+identical for both, but the reported setpoint ranges do not overlap
+(160-310 for Celsius, 610-880 for Fahrenheit), so the current status
+value is used to detect the Fahrenheit variants.
+
+For Fahrenheit variants, this quirk forces the temp_set datapoint to
+advertise a Fahrenheit unit so Home Assistant treats it as a Fahrenheit
+temperature control, and removes the redundant temp_set_f datapoint.
+Celsius variants are left untouched.
 """
+
+from tuya_sharing import CustomerDevice
 
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.builder import DeviceQuirk
 from tuya_device_handlers.const import DPMode
+
+
+def _is_fahrenheit_variant(device: CustomerDevice) -> bool:
+    """Check if the device reports temp_set in Fahrenheit."""
+    raw_value = device.status.get("temp_set")
+    return isinstance(raw_value, int) and raw_value >= 450
+
 
 (
     DeviceQuirk()
@@ -21,7 +38,12 @@ from tuya_device_handlers.const import DPMode
         max=880,
         scale=1,
         step=5,
+        apply_when=_is_fahrenheit_variant,
     )
-    .remove_dpid(dpid=136, dpcode="temp_set_f")
+    .remove_dpid(
+        dpid=136,
+        dpcode="temp_set_f",
+        apply_when=_is_fahrenheit_variant,
+    )
     .register(TUYA_QUIRKS_REGISTRY)
 )

--- a/tests/devices/kt/test_hw50w7qvxluhslkk.py
+++ b/tests/devices/kt/test_hw50w7qvxluhslkk.py
@@ -8,10 +8,10 @@ from tuya_device_handlers.helpers.homeassistant import TuyaUnitOfTemperature
 from tuya_device_handlers.registry import QuirksRegistry
 
 
-def test_default_definition(
+def test_fahrenheit_variant(
     filled_quirks_registry: QuirksRegistry,
 ) -> None:
-    """Test quirk adds missing datapoints."""
+    """Test the quirk fixes the unit on a Fahrenheit variant."""
     device = create_device("kt_hw50w7qvxluhslkk.json")
 
     climate_definition = get_climate_definition(
@@ -33,27 +33,19 @@ def test_default_definition(
     assert set_temperature_wrapper is not None
     assert set_temperature_wrapper.read_device_status(device) == 65
     assert set_temperature_wrapper.native_unit == "℉"
+    assert "temp_set_f" not in device.status_range
+    assert "temp_set_f" not in device.function
 
 
-def test_celsius_variant_is_forced_to_fahrenheit(
+def test_celsius_variant_is_left_untouched(
     filled_quirks_registry: QuirksRegistry,
 ) -> None:
-    """Document the current bug on a Celsius variant of the same product_id.
+    """Test the quirk leaves a Celsius variant of the same product_id alone.
 
     This product_id is shared with units that report temp_set in Celsius.
-    The quirk forces the unit to Fahrenheit for all of them, so a Celsius
-    device ends up with the wrong unit (see #385).
+    The quirk should only apply to the Fahrenheit variants (see #385).
     """
     device = create_device("kt_hw50w7qvxluhslkk_celsius.json")
-
-    climate_definition = get_climate_definition(
-        device, TuyaUnitOfTemperature.CELSIUS
-    )
-    assert climate_definition is not None
-    set_temperature_wrapper = climate_definition.set_temperature_wrapper
-    assert set_temperature_wrapper is not None
-    assert set_temperature_wrapper.read_device_status(device) == 26
-    assert set_temperature_wrapper.native_unit == "℃"
 
     filled_quirks_registry.initialise_device_quirk(device)
 
@@ -63,5 +55,7 @@ def test_celsius_variant_is_forced_to_fahrenheit(
     assert climate_definition is not None
     set_temperature_wrapper = climate_definition.set_temperature_wrapper
     assert set_temperature_wrapper is not None
-    # The device reports 26°C, but the quirk relabels it as Fahrenheit.
-    assert set_temperature_wrapper.native_unit == "℉"
+    assert set_temperature_wrapper.read_device_status(device) == 26
+    assert set_temperature_wrapper.native_unit == "℃"
+    assert "temp_set_f" in device.status_range
+    assert "temp_set_f" in device.function


### PR DESCRIPTION
## Summary

Last of the three PRs for #385, this is the actual fix.

The quirk now only applies to units that report `temp_set` in Fahrenheit. It tells the variants apart by the reported setpoint: Celsius units report 160-310 (16.0 to 31.0 °C), Fahrenheit units report 610-880 (61.0 to 88.0 °F), and the ranges don't overlap. Celsius units are left with their original definition, so they read and set correctly again.

The Celsius test from the first PR now checks the fixed behavior instead of the bug.

## Test plan

Verified on my own HAOS 2026.7.1 install with the same logic as a custom quirk in `/config/tuya_quirks/`: the 3 Celsius ACs read and set temperatures correctly, and the Fahrenheit fixture from #145 still works in the tests.

## Related issue

Fixes #385

---

I'll also open a follow-up PR to migrate the local strategy to the same base class and list storage, as suggested in #411.
