### PR TITLE
Add support for hex-encoded String colour_data

### DIFF
--- a/src/tuya_device_handlers/definition/light.py
+++ b/src/tuya_device_handlers/definition/light.py
@@ -19,6 +19,7 @@ from tuya_device_handlers.device_wrapper.light import (
     DEFAULT_S_TYPE_V2,
     DEFAULT_V_TYPE_V2,
     BrightnessWrapper,
+    ColorDataJsonWrapper,
     ColorDataStringWrapper,
     ColorDataWrapper,
     ColorTempWrapper,
@@ -141,39 +142,92 @@ def _get_color_data_wrapper(
     *,
     color_data_dpcode: str | tuple[str, ...] | None,
     fallback_color_data_mode: FallbackColorDataMode,
-) -> ColorDataWrapper | ColorDataStringWrapper | None:
-    color_data_wrapper: ColorDataWrapper | ColorDataStringWrapper | None
-    if color_data_wrapper := ColorDataWrapper.find_dpcode(
-        device, color_data_dpcode, prefer_function=True
+) -> ColorDataWrapper | None:
+    if json_wrapper := _get_color_data_json_wrapper(
+        device,
+        brightness_wrapper,
+        color_data_dpcode=color_data_dpcode,
+        fallback_color_data_mode=fallback_color_data_mode,
     ):
-        # JSON colour_data may describe its own h/s/v ranges
-        if function_data := json.loads(
-            color_data_wrapper.type_information.type_data
-        ):
-            h_type = function_data.get("h", {"min": 0, "max": 360})
-            s_type = function_data.get("s", {"min": 0, "max": 255})
-            v_type = function_data.get("v", {"min": 0, "max": 255})
-            color_data_wrapper.h_type = RemapHelper.from_function_data(
-                cast(dict[str, Any], h_type), 0, 360
-            )
-            color_data_wrapper.s_type = RemapHelper.from_function_data(
-                cast(dict[str, Any], s_type), 0, 100
-            )
-            color_data_wrapper.v_type = RemapHelper.from_function_data(
-                cast(dict[str, Any], v_type), 0, 255
-            )
-            return color_data_wrapper
-    elif not (
+        return json_wrapper
+    if string_wrapper := _get_color_data_string_wrapper(
+        device,
+        brightness_wrapper,
+        color_data_dpcode=color_data_dpcode,
+        fallback_color_data_mode=fallback_color_data_mode,
+    ):
+        return string_wrapper
+    return None
+
+
+def _get_color_data_json_wrapper(
+    device: CustomerDevice,
+    brightness_wrapper: BrightnessWrapper | None,
+    *,
+    color_data_dpcode: str | tuple[str, ...] | None,
+    fallback_color_data_mode: FallbackColorDataMode,
+) -> ColorDataJsonWrapper | None:
+    if not (
+        color_data_wrapper := ColorDataJsonWrapper.find_dpcode(
+            device, color_data_dpcode, prefer_function=True
+        )
+    ):
+        return None
+    # JSON colour_data may describe its own h/s/v ranges
+    if function_data := json.loads(
+        color_data_wrapper.type_information.type_data
+    ):
+        h_type = function_data.get("h", {"min": 0, "max": 360})
+        s_type = function_data.get("s", {"min": 0, "max": 255})
+        v_type = function_data.get("v", {"min": 0, "max": 255})
+        color_data_wrapper.h_type = RemapHelper.from_function_data(
+            cast(dict[str, Any], h_type), 0, 360
+        )
+        color_data_wrapper.s_type = RemapHelper.from_function_data(
+            cast(dict[str, Any], s_type), 0, 100
+        )
+        color_data_wrapper.v_type = RemapHelper.from_function_data(
+            cast(dict[str, Any], v_type), 0, 255
+        )
+        return color_data_wrapper
+    # JSON colour_data without explicit ranges
+    _apply_fallback_ranges(
+        color_data_wrapper,
+        brightness_wrapper,
+        fallback_color_data_mode=fallback_color_data_mode,
+    )
+    return color_data_wrapper
+
+
+def _get_color_data_string_wrapper(
+    device: CustomerDevice,
+    brightness_wrapper: BrightnessWrapper | None,
+    *,
+    color_data_dpcode: str | tuple[str, ...] | None,
+    fallback_color_data_mode: FallbackColorDataMode,
+) -> ColorDataStringWrapper | None:
+    if not (
         color_data_wrapper := ColorDataStringWrapper.find_dpcode(
             device, color_data_dpcode, prefer_function=True
         )
     ):
-        # Neither a JSON nor a hex-encoded colour_data datapoint
         return None
+    # Hex String DPs carry no range information at all
+    _apply_fallback_ranges(
+        color_data_wrapper,
+        brightness_wrapper,
+        fallback_color_data_mode=fallback_color_data_mode,
+    )
+    return color_data_wrapper
 
-    # Hex-encoded colour_data, or JSON colour_data without explicit ranges:
-    # fall back to the V1 (default) or V2 remap ranges. Hex String DPs carry
-    # no range info, so V2 selection relies on the checks below.
+
+def _apply_fallback_ranges(
+    color_data_wrapper: ColorDataWrapper,
+    brightness_wrapper: BrightnessWrapper | None,
+    *,
+    fallback_color_data_mode: FallbackColorDataMode,
+) -> None:
+    """Apply the V1 (default) or V2 remap ranges to a colour_data wrapper."""
     if (
         fallback_color_data_mode == FallbackColorDataMode.V2
         or color_data_wrapper.dpcode == "colour_data_v2"
@@ -182,5 +236,3 @@ def _get_color_data_wrapper(
         color_data_wrapper.h_type = DEFAULT_H_TYPE_V2
         color_data_wrapper.s_type = DEFAULT_S_TYPE_V2
         color_data_wrapper.v_type = DEFAULT_V_TYPE_V2
-
-    return color_data_wrapper

--- a/src/tuya_device_handlers/definition/light.py
+++ b/src/tuya_device_handlers/definition/light.py
@@ -19,6 +19,7 @@ from tuya_device_handlers.device_wrapper.light import (
     DEFAULT_S_TYPE_V2,
     DEFAULT_V_TYPE_V2,
     BrightnessWrapper,
+    ColorDataStringWrapper,
     ColorDataWrapper,
     ColorTempWrapper,
 )
@@ -140,31 +141,40 @@ def _get_color_data_wrapper(
     *,
     color_data_dpcode: str | tuple[str, ...] | None,
     fallback_color_data_mode: FallbackColorDataMode,
-) -> ColorDataWrapper | None:
-    if (
-        color_data_wrapper := ColorDataWrapper.find_dpcode(
+) -> ColorDataWrapper | ColorDataStringWrapper | None:
+    color_data_wrapper: ColorDataWrapper | ColorDataStringWrapper | None
+    if color_data_wrapper := ColorDataWrapper.find_dpcode(
+        device, color_data_dpcode, prefer_function=True
+    ):
+        # JSON colour_data may describe its own h/s/v ranges
+        if function_data := json.loads(
+            color_data_wrapper.type_information.type_data
+        ):
+            h_type = function_data.get("h", {"min": 0, "max": 360})
+            s_type = function_data.get("s", {"min": 0, "max": 255})
+            v_type = function_data.get("v", {"min": 0, "max": 255})
+            color_data_wrapper.h_type = RemapHelper.from_function_data(
+                cast(dict[str, Any], h_type), 0, 360
+            )
+            color_data_wrapper.s_type = RemapHelper.from_function_data(
+                cast(dict[str, Any], s_type), 0, 100
+            )
+            color_data_wrapper.v_type = RemapHelper.from_function_data(
+                cast(dict[str, Any], v_type), 0, 255
+            )
+            return color_data_wrapper
+    elif not (
+        color_data_wrapper := ColorDataStringWrapper.find_dpcode(
             device, color_data_dpcode, prefer_function=True
         )
-    ) is None:
+    ):
+        # Neither a JSON nor a hex-encoded colour_data datapoint
         return None
 
-    # Fetch color data type information
-    if function_data := json.loads(
-        color_data_wrapper.type_information.type_data
-    ):
-        h_type = function_data.get("h", {"min": 0, "max": 360})
-        s_type = function_data.get("s", {"min": 0, "max": 255})
-        v_type = function_data.get("v", {"min": 0, "max": 255})
-        color_data_wrapper.h_type = RemapHelper.from_function_data(
-            cast(dict[str, Any], h_type), 0, 360
-        )
-        color_data_wrapper.s_type = RemapHelper.from_function_data(
-            cast(dict[str, Any], s_type), 0, 100
-        )
-        color_data_wrapper.v_type = RemapHelper.from_function_data(
-            cast(dict[str, Any], v_type), 0, 255
-        )
-    elif (
+    # Hex-encoded colour_data, or JSON colour_data without explicit ranges:
+    # fall back to the V1 (default) or V2 remap ranges. Hex String DPs carry
+    # no range info, so V2 selection relies on the checks below.
+    if (
         fallback_color_data_mode == FallbackColorDataMode.V2
         or color_data_wrapper.dpcode == "colour_data_v2"
         or (brightness_wrapper and brightness_wrapper.max_value > 255)

--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -8,7 +8,7 @@ from tuya_sharing import CustomerDevice
 from tuya_device_handlers.type_information import IntegerTypeInformation
 from tuya_device_handlers.utils import RemapHelper
 
-from .common import DPCodeIntegerWrapper, DPCodeJsonWrapper
+from .common import DPCodeIntegerWrapper, DPCodeJsonWrapper, DPCodeStringWrapper
 
 
 class BrightnessWrapper(DPCodeIntegerWrapper[int]):
@@ -236,4 +236,49 @@ class ColorDataWrapper(DPCodeJsonWrapper[tuple[float, float, float]]):
                 "s": round(self.s_type.remap_value_from(saturation)),
                 "v": round(self.v_type.remap_value_from(brightness)),
             }
+        )
+
+
+class ColorDataStringWrapper(DPCodeStringWrapper[tuple[float, float, float]]):
+    """Wrapper for a hex-encoded color data DP code.
+
+    Some devices report ``colour_data`` (or ``colour_data_v2``) as a
+    ``String`` datapoint whose value packs the hue, saturation and value as
+    three consecutive 4-digit hexadecimal numbers (``HHHHSSSSVVVV``), instead
+    of the JSON object handled by ``ColorDataWrapper``.
+    """
+
+    h_type = DEFAULT_H_TYPE
+    s_type = DEFAULT_S_TYPE
+    v_type = DEFAULT_V_TYPE
+
+    def read_device_status(
+        self, device: CustomerDevice
+    ) -> tuple[float, float, float] | None:
+        """Return a tuple (H, S, V) from this color data."""
+        status = self._read_dpcode_value(device)
+        # Expect exactly "HHHHSSSSVVVV"; reject other types or lengths.
+        if not isinstance(status, str) or len(status) != 12:
+            return None
+        try:
+            hue = int(status[0:4], 16)
+            saturation = int(status[4:8], 16)
+            value = int(status[8:12], 16)
+        except ValueError:
+            return None
+        return (
+            self.h_type.remap_value_to(hue),
+            self.s_type.remap_value_to(saturation),
+            self.v_type.remap_value_to(value),
+        )
+
+    def _convert_value_to_raw_value(
+        self, device: CustomerDevice, value: tuple[float, float, float]
+    ) -> Any:
+        """Convert HA tuple (H, S, V) to a raw device value."""
+        hue, saturation, brightness = value
+        return (
+            f"{round(self.h_type.remap_value_from(hue)):04x}"
+            f"{round(self.s_type.remap_value_from(saturation)):04x}"
+            f"{round(self.v_type.remap_value_from(brightness)):04x}"
         )

--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -8,7 +8,12 @@ from tuya_sharing import CustomerDevice
 from tuya_device_handlers.type_information import IntegerTypeInformation
 from tuya_device_handlers.utils import RemapHelper
 
-from .common import DPCodeIntegerWrapper, DPCodeJsonWrapper, DPCodeStringWrapper
+from .common import (
+    DPCodeIntegerWrapper,
+    DPCodeJsonWrapper,
+    DPCodeStringWrapper,
+    DPCodeWrapper,
+)
 
 
 class BrightnessWrapper(DPCodeIntegerWrapper[int]):
@@ -206,12 +211,23 @@ DEFAULT_V_TYPE_V2 = RemapHelper(
 )
 
 
-class ColorDataWrapper(DPCodeJsonWrapper[tuple[float, float, float]]):
-    """Wrapper for color data DP code."""
+class ColorDataWrapper(DPCodeWrapper[tuple[float, float, float]]):
+    """Base for colour_data wrappers, holding the H/S/V remap ranges.
+
+    The ranges are set by the light definition once the encoding (V1 or
+    V2) is known, so every colour_data wrapper exposes them regardless of
+    how the datapoint itself is encoded.
+    """
 
     h_type = DEFAULT_H_TYPE
     s_type = DEFAULT_S_TYPE
     v_type = DEFAULT_V_TYPE
+
+
+class ColorDataJsonWrapper(
+    ColorDataWrapper, DPCodeJsonWrapper[tuple[float, float, float]]
+):
+    """Wrapper for a JSON-encoded color data DP code."""
 
     def read_device_status(
         self, device: CustomerDevice
@@ -239,18 +255,16 @@ class ColorDataWrapper(DPCodeJsonWrapper[tuple[float, float, float]]):
         )
 
 
-class ColorDataStringWrapper(DPCodeStringWrapper[tuple[float, float, float]]):
+class ColorDataStringWrapper(
+    ColorDataWrapper, DPCodeStringWrapper[tuple[float, float, float]]
+):
     """Wrapper for a hex-encoded color data DP code.
 
     Some devices report ``colour_data`` (or ``colour_data_v2``) as a
     ``String`` datapoint whose value packs the hue, saturation and value as
     three consecutive 4-digit hexadecimal numbers (``HHHHSSSSVVVV``), instead
-    of the JSON object handled by ``ColorDataWrapper``.
+    of the JSON object handled by ``ColorDataJsonWrapper``.
     """
-
-    h_type = DEFAULT_H_TYPE
-    s_type = DEFAULT_S_TYPE
-    v_type = DEFAULT_V_TYPE
 
     def read_device_status(
         self, device: CustomerDevice

--- a/tests/definition/test_light.py
+++ b/tests/definition/test_light.py
@@ -11,7 +11,9 @@ from tuya_device_handlers.device_wrapper.common import (
 )
 from tuya_device_handlers.device_wrapper.light import (
     BrightnessWrapper,
+    ColorDataStringWrapper,
     ColorDataWrapper,
+    ColorTempWrapper,
 )
 
 
@@ -75,3 +77,53 @@ def test_missing_colour_data_hsv() -> None:
     assert definition.color_mode_wrapper is None
     assert definition.color_temp_wrapper is None
     assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)
+
+
+def test_get_default_definition_hex_string_colour_data() -> None:
+    """Test hex-encoded String colour_data yields a ColorDataStringWrapper."""
+    device = create_device("hcdd_expmpw4xxd0kkifb.json")
+    assert (
+        definition := get_default_definition(
+            device,
+            switch_dpcode="switch_led",
+            brightness_dpcode=("bright_value_v2", "bright_value"),
+            brightness_max_dpcode=None,
+            brightness_min_dpcode=None,
+            color_data_dpcode=("colour_data_v2", "colour_data"),
+            color_mode_dpcode="work_mode",
+            color_temp_dpcode=("temp_value_v2", "temp_value"),
+            fallback_color_data_mode=FallbackColorDataMode.V1,
+        )
+    )
+    assert isinstance(definition.brightness_wrapper, BrightnessWrapper)
+    assert isinstance(definition.color_data_wrapper, ColorDataStringWrapper)
+    assert isinstance(definition.color_mode_wrapper, DPCodeEnumWrapper)
+    assert isinstance(definition.color_temp_wrapper, ColorTempWrapper)
+    assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)
+
+    # A brightness max above 255 selects the V2 remap ranges, so the hex
+    # value 007803e803e8 decodes to hue 120, saturation 100%, value 255.
+    assert definition.color_data_wrapper.read_device_status(device) == (
+        119.33147632311977,
+        100.0,
+        255.0,
+    )
+
+
+def test_get_default_definition_without_colour_data() -> None:
+    """Test a device without any colour_data has no color_data_wrapper."""
+    device = create_device("dj_mki13ie507rlry4r.json")
+    assert (
+        definition := get_default_definition(
+            device,
+            switch_dpcode="switch_led",
+            brightness_dpcode=("bright_value_v2", "bright_value"),
+            brightness_max_dpcode=None,
+            brightness_min_dpcode=None,
+            color_data_dpcode="does_not_exist",
+            color_mode_dpcode=None,
+            color_temp_dpcode=None,
+            fallback_color_data_mode=FallbackColorDataMode.V1,
+        )
+    )
+    assert definition.color_data_wrapper is None

--- a/tests/definition/test_light.py
+++ b/tests/definition/test_light.py
@@ -117,7 +117,7 @@ def test_get_default_definition_hex_string_colour_data() -> None:
 
 
 def test_get_default_definition_without_colour_data() -> None:
-    """Test a device without any colour_data has no color_data_wrapper."""
+    """Test an unmatched colour_data dpcode has no color_data_wrapper."""
     device = create_device("dj_mki13ie507rlry4r.json")
     assert (
         definition := get_default_definition(
@@ -176,6 +176,28 @@ def test_json_colour_data_without_ranges_v2() -> None:
     )
     assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
     # Empty type data, but a brightness max above 255 selects the V2 ranges
+    assert definition.color_data_wrapper.h_type is DEFAULT_H_TYPE_V2
+    assert definition.color_data_wrapper.s_type is DEFAULT_S_TYPE_V2
+    assert definition.color_data_wrapper.v_type is DEFAULT_V_TYPE_V2
+
+
+def test_json_colour_data_without_ranges_fallback_v2() -> None:
+    """Test JSON colour_data without ranges honours the V2 fallback mode."""
+    device = create_device("bzyd_45idzfufidgee7ir.json")
+    assert (
+        definition := get_default_definition(
+            device,
+            switch_dpcode="switch_led",
+            brightness_dpcode=None,
+            brightness_max_dpcode=None,
+            brightness_min_dpcode=None,
+            color_data_dpcode="colour_data",
+            color_mode_dpcode="work_mode",
+            color_temp_dpcode=None,
+            fallback_color_data_mode=FallbackColorDataMode.V2,
+        )
+    )
+    assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
     assert definition.color_data_wrapper.h_type is DEFAULT_H_TYPE_V2
     assert definition.color_data_wrapper.s_type is DEFAULT_S_TYPE_V2
     assert definition.color_data_wrapper.v_type is DEFAULT_V_TYPE_V2

--- a/tests/definition/test_light.py
+++ b/tests/definition/test_light.py
@@ -11,8 +11,8 @@ from tuya_device_handlers.device_wrapper.common import (
 )
 from tuya_device_handlers.device_wrapper.light import (
     BrightnessWrapper,
+    ColorDataJsonWrapper,
     ColorDataStringWrapper,
-    ColorDataWrapper,
     ColorTempWrapper,
 )
 
@@ -34,7 +34,7 @@ def test_get_default_definition() -> None:
         )
     )
     assert isinstance(definition.brightness_wrapper, BrightnessWrapper)
-    assert isinstance(definition.color_data_wrapper, ColorDataWrapper)
+    assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
     assert isinstance(definition.color_mode_wrapper, DPCodeEnumWrapper)
     assert not definition.color_temp_wrapper
     assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)
@@ -73,7 +73,7 @@ def test_missing_colour_data_hsv() -> None:
         )
     )
     assert definition.brightness_wrapper is None
-    assert isinstance(definition.color_data_wrapper, ColorDataWrapper)
+    assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
     assert definition.color_mode_wrapper is None
     assert definition.color_temp_wrapper is None
     assert isinstance(definition.switch_wrapper, DPCodeBooleanWrapper)

--- a/tests/definition/test_light.py
+++ b/tests/definition/test_light.py
@@ -10,6 +10,12 @@ from tuya_device_handlers.device_wrapper.common import (
     DPCodeEnumWrapper,
 )
 from tuya_device_handlers.device_wrapper.light import (
+    DEFAULT_H_TYPE,
+    DEFAULT_H_TYPE_V2,
+    DEFAULT_S_TYPE,
+    DEFAULT_S_TYPE_V2,
+    DEFAULT_V_TYPE,
+    DEFAULT_V_TYPE_V2,
     BrightnessWrapper,
     ColorDataJsonWrapper,
     ColorDataStringWrapper,
@@ -127,3 +133,49 @@ def test_get_default_definition_without_colour_data() -> None:
         )
     )
     assert definition.color_data_wrapper is None
+
+
+def test_json_colour_data_without_ranges() -> None:
+    """Test JSON colour_data without ranges falls back to the V1 ranges."""
+    device = create_device("bzyd_45idzfufidgee7ir.json")
+    assert (
+        definition := get_default_definition(
+            device,
+            switch_dpcode="switch_led",
+            brightness_dpcode=None,
+            brightness_max_dpcode=None,
+            brightness_min_dpcode=None,
+            color_data_dpcode="colour_data",
+            color_mode_dpcode="work_mode",
+            color_temp_dpcode=None,
+            fallback_color_data_mode=FallbackColorDataMode.V1,
+        )
+    )
+    assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
+    # Empty type data and no brightness DP: keep the V1 (default) ranges
+    assert definition.color_data_wrapper.h_type is DEFAULT_H_TYPE
+    assert definition.color_data_wrapper.s_type is DEFAULT_S_TYPE
+    assert definition.color_data_wrapper.v_type is DEFAULT_V_TYPE
+
+
+def test_json_colour_data_without_ranges_v2() -> None:
+    """Test JSON colour_data without ranges honours a >255 brightness."""
+    device = create_device("gyd_lgekqfxdabipm3tn.json")
+    assert (
+        definition := get_default_definition(
+            device,
+            switch_dpcode="switch_led",
+            brightness_dpcode="bright_value",
+            brightness_max_dpcode=None,
+            brightness_min_dpcode=None,
+            color_data_dpcode="colour_data",
+            color_mode_dpcode="work_mode",
+            color_temp_dpcode="temp_value",
+            fallback_color_data_mode=FallbackColorDataMode.V1,
+        )
+    )
+    assert isinstance(definition.color_data_wrapper, ColorDataJsonWrapper)
+    # Empty type data, but a brightness max above 255 selects the V2 ranges
+    assert definition.color_data_wrapper.h_type is DEFAULT_H_TYPE_V2
+    assert definition.color_data_wrapper.s_type is DEFAULT_S_TYPE_V2
+    assert definition.color_data_wrapper.v_type is DEFAULT_V_TYPE_V2

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -370,17 +370,39 @@ def test_color_data_string_read_device_status(
     assert wrapper
     assert wrapper.read_device_status(mock_device) == expected_device_status
 
-    # Non-hexadecimal (but correctly sized) values return None
-    mock_device.status["colour_data"] = "zzzzzzzzzzzz"
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        # Non-hexadecimal, but correctly sized
+        "zzzzzzzzzzzz",
+        # Wrongly sized
+        "0078",
+        "",
+        # Not a string at all
+        None,
+        123456,
+    ],
+)
+def test_color_data_string_invalid_status(
+    status: Any,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test unusable hex-encoded String colour_data values return None."""
+    _inject_hex_string_light(mock_device)
+    wrapper = ColorDataStringWrapper.find_dpcode(mock_device, "colour_data")
+
+    assert wrapper
+    mock_device.status["colour_data"] = status
     assert wrapper.read_device_status(mock_device) is None
 
-    # Wrongly-sized values return None
-    mock_device.status["colour_data"] = "0078"
-    assert wrapper.read_device_status(mock_device) is None
 
-    # None and missing status return None
-    mock_device.status["colour_data"] = None
-    assert wrapper.read_device_status(mock_device) is None
+def test_color_data_string_missing_status(mock_device: CustomerDevice) -> None:
+    """Test a missing hex-encoded String colour_data returns None."""
+    _inject_hex_string_light(mock_device)
+    wrapper = ColorDataStringWrapper.find_dpcode(mock_device, "colour_data")
+
+    assert wrapper
     mock_device.status.pop("colour_data")
     assert wrapper.read_device_status(mock_device) is None
 

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -11,6 +11,7 @@ from tuya_device_handlers.device_wrapper.common import (
 )
 from tuya_device_handlers.device_wrapper.light import (
     BrightnessWrapper,
+    ColorDataStringWrapper,
     ColorDataWrapper,
     ColorTempWrapper,
 )
@@ -332,4 +333,79 @@ def test_light_action_command(
                 brightness_wrapper.brightness_min.type_information, 0, 255
             )
         )
+    assert wrapper.get_update_commands(mock_device, action) == expected
+
+
+def _inject_hex_string_light(mock_device: CustomerDevice) -> None:
+    """Inject a light whose colour_data is a hex-encoded String DP."""
+    inject_dpcode(
+        mock_device,
+        "colour_data",
+        "007803e803e8",
+        dptype="String",
+        values='{"maxlen": 255}',
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_device_status"),
+    [
+        (
+            "007800800040",
+            (119.33147632311977, 50.0, 63.24803149606299),
+        ),
+        ("00b400ff0080", (179.49860724233983, 100.0, 127.5)),
+    ],
+)
+def test_color_data_string_read_device_status(
+    status: str,
+    expected_device_status: tuple[float, float, float],
+    mock_device: CustomerDevice,
+) -> None:
+    """Test read_device_status for hex-encoded String colour_data."""
+    _inject_hex_string_light(mock_device)
+    mock_device.status["colour_data"] = status
+    wrapper = ColorDataStringWrapper.find_dpcode(mock_device, "colour_data")
+
+    assert wrapper
+    assert wrapper.read_device_status(mock_device) == expected_device_status
+
+    # Non-hexadecimal (but correctly sized) values return None
+    mock_device.status["colour_data"] = "zzzzzzzzzzzz"
+    assert wrapper.read_device_status(mock_device) is None
+
+    # Wrongly-sized values return None
+    mock_device.status["colour_data"] = "0078"
+    assert wrapper.read_device_status(mock_device) is None
+
+    # None and missing status return None
+    mock_device.status["colour_data"] = None
+    assert wrapper.read_device_status(mock_device) is None
+    mock_device.status.pop("colour_data")
+    assert wrapper.read_device_status(mock_device) is None
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [
+        (
+            (119.33147632311977, 50.0, 63.24803149606299),
+            [{"code": "colour_data", "value": "007800800040"}],
+        ),
+        (
+            (179.49860724233983, 100.0, 127.5),
+            [{"code": "colour_data", "value": "00b400ff0080"}],
+        ),
+    ],
+)
+def test_color_data_string_action_command(
+    action: tuple[float, float, float],
+    expected: list[dict[str, Any]],
+    mock_device: CustomerDevice,
+) -> None:
+    """Test get_update_commands for hex-encoded String colour_data."""
+    _inject_hex_string_light(mock_device)
+    wrapper = ColorDataStringWrapper.find_dpcode(mock_device, "colour_data")
+
+    assert wrapper
     assert wrapper.get_update_commands(mock_device, action) == expected

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -11,8 +11,8 @@ from tuya_device_handlers.device_wrapper.common import (
 )
 from tuya_device_handlers.device_wrapper.light import (
     BrightnessWrapper,
+    ColorDataJsonWrapper,
     ColorDataStringWrapper,
-    ColorDataWrapper,
     ColorTempWrapper,
 )
 from tuya_device_handlers.utils import RemapHelper
@@ -82,7 +82,7 @@ def _inject_default_light(mock_device: CustomerDevice) -> None:
         ),
         (
             "default",
-            ColorDataWrapper,
+            ColorDataJsonWrapper,
             "colour_data",
             {},
             (228.6350974930362, 393.3070866141732, 1002.9330708661417),
@@ -215,7 +215,7 @@ def test_read_device_status(
         ),
         (
             "default",
-            ColorDataWrapper,
+            ColorDataJsonWrapper,
             "colour_data",
             (228.6350974930362, 393.3070866141732, 1002.9330708661417),
             [

--- a/tests/fixtures/devices/bzyd_45idzfufidgee7ir.json
+++ b/tests/fixtures/devices/bzyd_45idzfufidgee7ir.json
@@ -1,0 +1,137 @@
+{
+  "name": "Smart White Noise Machine",
+  "category": "bzyd",
+  "product_id": "45idzfufidgee7ir",
+  "product_name": "Smart White Noise Machine",
+  "online": true,
+  "sub": false,
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene", "customize_scene", "colour"]
+      }
+    },
+    "switch_led": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "colour_data": {
+      "type": "Json",
+      "value": {}
+    },
+    "switch_music": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "volume_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "stop": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 0,
+        "max": 1440,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["scene", "customize_scene", "colour"]
+      }
+    },
+    "switch_led": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "colour_data": {
+      "type": "String",
+      "value": {}
+    },
+    "switch_music": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "volume_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "stop": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "status": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "manual",
+          "wake_up_1",
+          "wake_up_2",
+          "wake_up_3",
+          "wake_up_4",
+          "sleep_1",
+          "sleep_2",
+          "sleep_3",
+          "sleep_4"
+        ]
+      }
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 0,
+        "max": 1440,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "switch": false,
+    "work_mode": "scene",
+    "switch_led": true,
+    "colour_data": {
+      "h": 240,
+      "s": 1000,
+      "v": 1000
+    },
+    "switch_music": true,
+    "volume_set": 17,
+    "stop": false,
+    "status": "manual",
+    "countdown": 0
+  },
+  "set_up": false,
+  "support_local": true
+}

--- a/tests/fixtures/devices/gyd_lgekqfxdabipm3tn.json
+++ b/tests/fixtures/devices/gyd_lgekqfxdabipm3tn.json
@@ -1,0 +1,260 @@
+{
+  "mqtt_connected": true,
+  "name": "Colorful PIR Night Light",
+  "category": "gyd",
+  "product_id": "lgekqfxdabipm3tn",
+  "product_name": "Colorful PIR Night Light",
+  "online": true,
+  "sub": false,
+  "time_zone": "+07:00",
+  "active_time": "2024-07-18T12:02:37+00:00",
+  "create_time": "2024-07-18T12:02:37+00:00",
+  "update_time": "2024-07-18T12:02:37+00:00",
+  "function": {
+    "switch_led": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["white", "colour", "scene", "music"]
+      }
+    },
+    "bright_value": {
+      "type": "Integer",
+      "value": {
+        "min": 10,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_value": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "colour_data": {
+      "type": "Json",
+      "value": {}
+    },
+    "scene_data": {
+      "type": "Json",
+      "value": {}
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "control_data": {
+      "type": "String",
+      "value": {
+        "maxlen": 255
+      }
+    },
+    "device_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["auto", "manual"]
+      }
+    },
+    "cds": {
+      "type": "Enum",
+      "value": {
+        "range": ["2000lux", "300lux", "50lux", "10lux", "5lux"]
+      }
+    },
+    "pir_sensitivity": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "middle", "high"]
+      }
+    },
+    "pir_delay": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 5,
+        "max": 3600,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_pir": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "standby_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 1,
+        "max": 480,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "standby_bright": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status_range": {
+    "switch_led": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["white", "colour", "scene", "music"]
+      }
+    },
+    "bright_value": {
+      "type": "Integer",
+      "value": {
+        "min": 10,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_value": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "colour_data": {
+      "type": "Json",
+      "value": {}
+    },
+    "scene_data": {
+      "type": "Json",
+      "value": {}
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "device_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["auto", "manual"]
+      }
+    },
+    "pir_state": {
+      "type": "Enum",
+      "value": {
+        "range": ["pir", "none"]
+      }
+    },
+    "cds": {
+      "type": "Enum",
+      "value": {
+        "range": ["2000lux", "300lux", "50lux", "10lux", "5lux"]
+      }
+    },
+    "pir_sensitivity": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "middle", "high"]
+      }
+    },
+    "pir_delay": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 5,
+        "max": 3600,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_pir": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "standby_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 1,
+        "max": 480,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "standby_bright": {
+      "type": "Integer",
+      "value": {
+        "min": 0,
+        "max": 1000,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "switch_led": false,
+    "work_mode": "white",
+    "bright_value": 1000,
+    "temp_value": 1,
+    "colour_data": {
+      "h": 0,
+      "s": 1000,
+      "v": 1000
+    },
+    "scene_data": {
+      "scene_num": 1,
+      "scene_units": [
+        {
+          "bright": 200,
+          "h": 0,
+          "s": 0,
+          "temperature": 0,
+          "unit_change_mode": "static",
+          "unit_gradient_duration": 13,
+          "unit_switch_duration": 14,
+          "v": 0
+        }
+      ]
+    },
+    "countdown": 0,
+    "device_mode": "auto",
+    "pir_state": "none",
+    "cds": "5lux",
+    "pir_sensitivity": "middle",
+    "pir_delay": 30,
+    "switch_pir": true,
+    "standby_time": 1,
+    "standby_bright": 146
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/fixtures/devices/hcdd_expmpw4xxd0kkifb.json
+++ b/tests/fixtures/devices/hcdd_expmpw4xxd0kkifb.json
@@ -1,0 +1,91 @@
+{
+  "name": "Chasing Tape Light",
+  "category": "hcdd",
+  "product_id": "expmpw4xxd0kkifb",
+  "product_name": "Chasing Tape Light",
+  "online": true,
+  "sub": false,
+  "function": {
+    "switch_led": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"white\",\"colour\",\"scene\",\"music\"]}"
+    },
+    "bright_value": {
+      "type": "Integer",
+      "value": "{\"min\":10,\"max\":1000,\"scale\":0,\"step\":1}"
+    },
+    "temp_value": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"max\":1000,\"scale\":0,\"step\":1}"
+    },
+    "colour_data": {
+      "type": "String",
+      "value": "{\"maxlen\":255}"
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
+    },
+    "music_data": {
+      "type": "String",
+      "value": "{\"maxlen\":255}"
+    },
+    "lightpixel_number_set": {
+      "type": "Integer",
+      "value": "{\"min\":1,\"max\":1000,\"scale\":1,\"step\":1}"
+    }
+  },
+  "status_range": {
+    "switch_led": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"white\",\"colour\",\"scene\",\"music\"]}"
+    },
+    "bright_value": {
+      "type": "Integer",
+      "value": "{\"min\":10,\"max\":1000,\"scale\":0,\"step\":1}"
+    },
+    "temp_value": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"max\":1000,\"scale\":0,\"step\":1}"
+    },
+    "colour_data": {
+      "type": "String",
+      "value": "{\"maxlen\":255}"
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
+    },
+    "light_length": {
+      "type": "Integer",
+      "value": "{\"unit\":\"cm\",\"min\":1,\"max\":10000,\"scale\":0,\"step\":1}"
+    },
+    "light_pixel": {
+      "type": "Integer",
+      "value": "{\"min\":1,\"max\":1024,\"scale\":0,\"step\":1}"
+    },
+    "lightpixel_number_set": {
+      "type": "Integer",
+      "value": "{\"min\":1,\"max\":1000,\"scale\":1,\"step\":1}"
+    }
+  },
+  "status": {
+    "switch_led": true,
+    "work_mode": "white",
+    "bright_value": 1000,
+    "temp_value": 0,
+    "colour_data": "007803e803e8",
+    "countdown": 0,
+    "light_length": 1200,
+    "light_pixel": 48,
+    "lightpixel_number_set": 24
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

Some Tuya lights report `colour_data` / `colour_data_v2` as a **String** datapoint whose value packs hue, saturation and value as three consecutive 4-digit hexadecimal numbers (`HHHHSSSSVVVV`), instead of the JSON object handled by `ColorDataWrapper`. Because `find_dpcode` only matches the JSON DP type, these devices currently get **no color wrapper at all** and therefore lose HS color support.

Example: the `hcdd` "Chasing Tape Light" (product `expmpw4xxd0kkifb`) reports `colour_data` = `007803e803e8` (hue 120, saturation 1000, value 1000). This hex encoding was supported by the old Home Assistant Tuya integration before the move to this library.

This PR:

- Adds `ColorDataStringWrapper` (a `DPCodeStringWrapper`) that decodes the hex representation (`int(value[0:4], 16)`, `[4:8]`, `[8:12]`) into `(H, S, V)` using the same V1/V2 `RemapHelper`s as `ColorDataWrapper`, and encodes HA values back to `{:04x}{:04x}{:04x}`.
- Updates `_get_color_data_wrapper` to try `ColorDataWrapper` (JSON) first and fall back to `ColorDataStringWrapper` when no JSON `colour_data` datapoint is present. **Existing JSON behavior is unchanged** (the V1/V2 range-selection logic is shared by both paths).

## Test plan

<!-- How was it tested? -->

- `tests/device_wrapper/test_light.py`: read + write cases for the hex wrapper, plus non-hex / `None` / missing-status edge cases (all return `None`).
- `tests/definition/test_light.py`: `get_default_definition` on a real `hcdd` fixture yields a `ColorDataStringWrapper` and decodes to the expected HSV; a device with no `colour_data` yields `None`.
- `tests/fixtures/devices/hcdd_expmpw4xxd0kkifb.json`: new fixture (String `colour_data`).

Local checks all pass:

- `ruff check .` / `ruff format --check .`
- `ty check src tests`
- `pylint src/tuya_device_handlers` (10.00/10)
- `codespell`
- `pytest --cov tuya_device_handlers tests`: 424 passed, 98.19% coverage

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->

Enables the color half of home-assistant/core#177044 (mapping the `hcdd` category to a light profile).
