### PR TITLE
Add quirk for Kogan portable AC (crh9iaqFowdJX5UY)

### DIFF
--- a/src/tuya_device_handlers/devices/kt/kt_crh9iaqfowdjx5uy.py
+++ b/src/tuya_device_handlers/devices/kt/kt_crh9iaqfowdjx5uy.py
@@ -1,0 +1,39 @@
+"""Quirk for the Kogan portable AC crh9iaqFowdJX5UY."""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+READ_WRITE = DPMode.READ | DPMode.WRITE
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="crh9iaqFowdJX5UY")
+    .add_dpid_integer(
+        dpid=2,
+        dpcode="temp_set",
+        dpmode=READ_WRITE,
+        unit="℃",
+        min=16,
+        max=30,
+        scale=0,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=3,
+        dpcode="temp_current",
+        dpmode=DPMode.READ,
+        unit="℃",
+        min=-7,
+        max=98,
+        scale=0,
+        step=1,
+    )
+    .add_dpid_enum(
+        dpid=4,
+        dpcode="mode",
+        dpmode=READ_WRITE,
+        enum_range=["cold", "hot", "wet", "wind"],
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/src/tuya_device_handlers/devices/kt/kt_crh9iaqfowdjx5uy.py
+++ b/src/tuya_device_handlers/devices/kt/kt_crh9iaqfowdjx5uy.py
@@ -4,15 +4,13 @@ from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.builder import DeviceQuirk
 from tuya_device_handlers.const import DPMode
 
-READ_WRITE = DPMode.READ | DPMode.WRITE
-
 (
     DeviceQuirk()
     .applies_to(product_id="crh9iaqFowdJX5UY")
     .add_dpid_integer(
         dpid=2,
         dpcode="temp_set",
-        dpmode=READ_WRITE,
+        dpmode=DPMode.READ | DPMode.WRITE,
         unit="℃",
         min=16,
         max=30,
@@ -32,7 +30,7 @@ READ_WRITE = DPMode.READ | DPMode.WRITE
     .add_dpid_enum(
         dpid=4,
         dpcode="mode",
-        dpmode=READ_WRITE,
+        dpmode=DPMode.READ | DPMode.WRITE,
         enum_range=["cold", "hot", "wet", "wind"],
     )
     .register(TUYA_QUIRKS_REGISTRY)

--- a/tests/devices/kt/test_crh9iaqfowdjx5uy.py
+++ b/tests/devices/kt/test_crh9iaqfowdjx5uy.py
@@ -1,0 +1,65 @@
+"""Test the Kogan portable AC quirk."""
+
+import json
+
+from tests import create_device
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_portable_ac_datapoints(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Test the quirk corrects the temperature and HVAC mode schemas."""
+    device = create_device("kt_crh9iaqFowdJX5UY.json")
+
+    assert "temp_current" not in device.status_range
+    assert json.loads(device.function["temp_set"].values) == {
+        "min": 0,
+        "unit": "℃",
+        "scale": 0,
+        "max": 50,
+        "step": 1,
+    }
+    assert json.loads(device.function["mode"].values)["range"] == [
+        "auto",
+        "cold",
+        "hot",
+        "wet",
+        "wind",
+        "eco",
+    ]
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    expected_temperature_range = {
+        "unit": "℃",
+        "min": 16,
+        "max": 30,
+        "scale": 0,
+        "step": 1,
+    }
+    assert json.loads(device.function["temp_set"].values) == (
+        expected_temperature_range
+    )
+    assert json.loads(device.status_range["temp_set"].values) == (
+        expected_temperature_range
+    )
+    assert json.loads(device.status_range["temp_current"].values) == {
+        "unit": "℃",
+        "min": -7,
+        "max": 98,
+        "scale": 0,
+        "step": 1,
+    }
+    assert json.loads(device.function["mode"].values)["range"] == [
+        "cold",
+        "hot",
+        "wet",
+        "wind",
+    ]
+    assert json.loads(device.status_range["mode"].values)["range"] == [
+        "cold",
+        "hot",
+        "wet",
+        "wind",
+    ]

--- a/tests/fixtures/devices/kt_crh9iaqFowdJX5UY.json
+++ b/tests/fixtures/devices/kt_crh9iaqFowdJX5UY.json
@@ -1,0 +1,258 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Smart Portable AC",
+  "category": "kt",
+  "product_id": "crh9iaqFowdJX5UY",
+  "product_name": "Smart Portable AC",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2026-01-18T11:14:13+00:00",
+  "create_time": "2026-01-18T11:14:13+00:00",
+  "update_time": "2026-01-18T11:14:13+00:00",
+  "function": {
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\": \"\\u2103\", \"min\": 16, \"max\": 30, \"scale\": 0, \"step\": 1}"
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": "{\"range\":[\"1\",\"2\",\"3\"]}"
+    },
+    "c_f": {
+      "type": "Enum",
+      "value": "{\"range\":[\"C\",\"F\"]}"
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\": [\"cold\", \"hot\", \"wet\", \"wind\"]}"
+    }
+  },
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "c_f",
+      "config_item": {
+        "statusFormat": "{\"c_f\":\"$\"}",
+        "valueDesc": "{\"range\":[\"C\",\"F\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "windspeed",
+      "config_item": {
+        "statusFormat": "{\"windspeed\":\"$\"}",
+        "valueDesc": "{\"range\":[\"1\",\"2\",\"3\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "4": {
+      "value_convert": "default",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\": \"$\"}",
+        "valueDesc": "{\"range\": [\"cold\", \"hot\", \"wet\", \"wind\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "temp_set",
+      "config_item": {
+        "statusFormat": "{\"temp_set\": \"$\"}",
+        "valueDesc": "{\"unit\": \"\\u2103\", \"min\": 16, \"max\": 30, \"scale\": 0, \"step\": 1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "3": {
+      "value_convert": "default",
+      "status_code": "temp_current",
+      "config_item": {
+        "statusFormat": "{\"temp_current\": \"$\"}",
+        "valueDesc": "{\"unit\": \"\\u2103\", \"min\": -7, \"max\": 98, \"scale\": 0, \"step\": 1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "c_f": {
+      "type": "Enum",
+      "value": "{\"range\":[\"C\",\"F\"]}",
+      "report_type": null
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": "{\"range\":[\"1\",\"2\",\"3\"]}",
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\": [\"cold\", \"hot\", \"wet\", \"wind\"]}",
+      "report_type": null
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"unit\": \"\\u2103\", \"min\": 16, \"max\": 30, \"scale\": 0, \"step\": 1}",
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": "{\"unit\": \"\\u2103\", \"min\": -7, \"max\": 98, \"scale\": 0, \"step\": 1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "mode": "hot",
+    "windspeed": "3",
+    "c_f": "C",
+    "temp_set": 22,
+    "temp_current": 23
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": "/config/tuya_quirks/kt_crh9iaqfowdjx5uy.py:9",
+  "warnings": null,
+  "original_category": "kt",
+  "original_function": {
+    "temp_set": {
+      "type": "Integer",
+      "value": "{\"min\":0,\"unit\":\"\\u2103\",\"scale\":0,\"max\":50,\"step\":1}"
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": "{\"range\":[\"1\",\"2\",\"3\"]}"
+    },
+    "c_f": {
+      "type": "Enum",
+      "value": "{\"range\":[\"C\",\"F\"]}"
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"auto\",\"cold\",\"hot\",\"wet\",\"wind\",\"eco\"]}"
+    }
+  },
+  "original_local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "c_f",
+      "config_item": {
+        "statusFormat": "{\"c_f\":\"$\"}",
+        "valueDesc": "{\"range\":[\"C\",\"F\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "5": {
+      "value_convert": "default",
+      "status_code": "windspeed",
+      "config_item": {
+        "statusFormat": "{\"windspeed\":\"$\"}",
+        "valueDesc": "{\"range\":[\"1\",\"2\",\"3\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    },
+    "4": {
+      "value_convert": "enum",
+      "status_code": "mode",
+      "config_item": {
+        "statusFormat": "{\"mode\":\"$\"}",
+        "valueDesc": "{\"range\":[\"auto\",\"cold\",\"hot\",\"wet\",\"wind\",\"eco\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {
+          "COOL": {
+            "code": "mode",
+            "value": "cold"
+          },
+          "DRY": {
+            "code": "mode",
+            "value": "wet"
+          },
+          "FAN": {
+            "code": "mode",
+            "value": "wind"
+          },
+          "HEAT": {
+            "code": "mode",
+            "value": "hot"
+          }
+        },
+        "pid": "crh9iaqFowdJX5UY"
+      }
+    }
+  },
+  "original_status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "c_f": {
+      "type": "Enum",
+      "value": "{\"range\":[\"C\",\"F\"]}",
+      "report_type": null
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": "{\"range\":[\"1\",\"2\",\"3\"]}",
+      "report_type": null
+    },
+    "mode": {
+      "type": "Enum",
+      "value": "{\"range\":[\"auto\",\"cold\",\"hot\",\"wet\",\"wind\",\"eco\"]}",
+      "report_type": null
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a device quirk for the Kogan portable AC with product ID `crh9iaqFowdJX5UY`.

The Tuya cloud schema advertises an overly broad 0–50 °C setpoint range, omits the readable current-temperature datapoint, and includes unsupported `auto` and `eco` HVAC modes. This quirk:

- constrains `temp_set` to the tested 16–30 °C range
- adds readable `temp_current`
- exposes only the supported `cold`, `hot`, `wet`, and `wind` modes
- includes a sanitized real-device diagnostic fixture and focused regression test

## Test plan

- `poetry run pytest --cov tuya_device_handlers tests`
  - 425 tests passed
  - 97.89% total coverage
- `poetry run ruff check .`
- `poetry run ruff format --check .`
- `poetry run ty check src tests`

Tested locally as a custom quirk in Home Assistant.

## Related issue

None.