### PR TITLE
Fix Tuya vacuum cleaning state detection

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/vacuum.py
+++ b/src/tuya_device_handlers/device_wrapper/vacuum.py
@@ -42,23 +42,46 @@ class VacuumActivityWrapper(DeviceWrapper[TuyaVacuumActivity]):
         "zone_clean": TuyaVacuumActivity.CLEANING,
     }
 
+    # `mode` values that indicate the vacuum is actively cleaning.
+    # Some devices report `status: charging` even while actively
+    # cleaning in one of these modes (see #178209); in that case
+    # `mode` is more trustworthy than `status`.
+    _ACTIVE_CLEANING_MODES = {
+        "smart",
+        "smart_clean",
+        "zone_clean",
+        "part_clean",
+        "pick_zone_clean",
+        "spot_clean",
+        "wall_clean",
+        "wall_follow",
+        "random",
+    }
+
     def __init__(
         self,
         pause_wrapper: DPCodeBooleanWrapper | None = None,
         status_wrapper: DPCodeEnumWrapper | None = None,
+        mode_wrapper: DPCodeEnumWrapper | None = None,
     ) -> None:
         """Init _VacuumActivityWrapper."""
         self._pause_wrapper = pause_wrapper
         self._status_wrapper = status_wrapper
+        self._mode_wrapper = mode_wrapper
 
     @classmethod
     def find_dpcode(cls, device: CustomerDevice) -> Self | None:
         """Find and return a _VacuumActivityWrapper for the given DP codes."""
         pause_wrapper = DPCodeBooleanWrapper.find_dpcode(device, "pause")
         status_wrapper = DPCodeEnumWrapper.find_dpcode(device, "status")
+        mode_wrapper = DPCodeEnumWrapper.find_dpcode(
+            device, "mode", prefer_function=True
+        )
         if pause_wrapper or status_wrapper:
             return cls(
-                pause_wrapper=pause_wrapper, status_wrapper=status_wrapper
+                pause_wrapper=pause_wrapper,
+                status_wrapper=status_wrapper,
+                mode_wrapper=mode_wrapper,
             )
         return None
 
@@ -71,7 +94,18 @@ class VacuumActivityWrapper(DeviceWrapper[TuyaVacuumActivity]):
             and (status := self._status_wrapper.read_device_status(device))
             is not None
         ):
-            return self._TUYA_STATUS_TO_HA.get(status)
+            activity = self._TUYA_STATUS_TO_HA.get(status)
+            # Some devices report status "charging" while actively
+            # cleaning in certain modes (e.g. "smart"). When that
+            # happens, trust `mode` over `status`. See #178209.
+            if (
+                activity == TuyaVacuumActivity.DOCKED
+                and self._mode_wrapper
+                and self._mode_wrapper.read_device_status(device)
+                in self._ACTIVE_CLEANING_MODES
+            ):
+                return TuyaVacuumActivity.CLEANING
+            return activity
 
         if self._pause_wrapper and self._pause_wrapper.read_device_status(
             device

--- a/tests/device_wrapper/test_vacuum.py
+++ b/tests/device_wrapper/test_vacuum.py
@@ -45,6 +45,20 @@ from . import inject_dpcode
             {"pause": False},
             None,
         ),
+        # Regression test for #178209: device reports status
+        # "charging" while actively cleaning in "smart" mode.
+        (
+            "status_and_mode_wrapper",
+            {"status": "charging", "mode": "smart"},
+            TuyaVacuumActivity.CLEANING,
+        ),
+        # Same status/mode wrapper present, but mode is NOT an
+        # active-cleaning mode -> should stay DOCKED as normal.
+        (
+            "status_and_mode_wrapper",
+            {"status": "charging", "mode": "chargego"},
+            TuyaVacuumActivity.DOCKED,
+        ),
     ],
 )
 def test_read_device_status(
@@ -55,13 +69,21 @@ def test_read_device_status(
 ) -> None:
     """Test read_device_status."""
     inject_dpcode(mock_device, "pause", False, dptype="Boolean")
-    if sample == "status_wrapper":
+    if sample in ("status_wrapper", "status_and_mode_wrapper"):
         inject_dpcode(
             mock_device,
             "status",
             "charge_done",
             dptype="Enum",
             values='{"range": ["standby","zone_clean","part_clean","cleaning","paused","goto_pos","pos_arrived","pos_unarrive","goto_charge","charging","charge_done","sleep"]}',  # noqa: E501
+        )
+    if sample == "status_and_mode_wrapper":
+        inject_dpcode(
+            mock_device,
+            "mode",
+            "chargego",
+            dptype="Enum",
+            values='{"range": ["random", "smart", "wall_follow", "chargego"]}',
         )
 
     mock_device.status.update(status_updates)


### PR DESCRIPTION
## Summary

This PR fixes an issue where some Tuya vacuum devices incorrectly report their state as `charging` while they are actively cleaning.

The vacuum activity detection previously relied only on the `status` DP code. For affected devices, the status value remains `charging` during active cleaning modes (for example, `smart` mode), causing Home Assistant to incorrectly show the vacuum as docked instead of cleaning.

This change:
- Adds support for reading the vacuum `mode` DP code in `VacuumActivityWrapper`.
- Adds a list of known active cleaning modes.
- Overrides the `charging` status when the device reports an active cleaning mode, returning `CLEANING` instead.
- Adds regression tests covering:
  - `status: charging` + `mode: smart` → `CLEANING`
  - `status: charging` + non-cleaning mode → `DOCKED`

The fix is implemented here because Tuya device state interpretation happens inside `tuya-device-handlers`, which is the library responsible for mapping raw Tuya DP codes into normalized device states used by Home Assistant.

## Test plan

Tests added/updated:
- `tests/device_wrapper/test_vacuum.py`

Verified with:

```bash
python -m pytest tests/device_wrapper/test_vacuum.py -v

poetry run pre-commit run --files src/tuya_device_handlers/device_wrapper/vacuum.py tests/device_wrapper/test_vacuum.py

All checks passed.

Related issue

Fixes #178209