### PR TITLE
Add quirk for Double Digital Meter (dhto3y4uachr1wll)

### DIFF
--- a/src/tuya_device_handlers/devices/cz/cz_dhto3y4uachr1wll.py
+++ b/src/tuya_device_handlers/devices/cz/cz_dhto3y4uachr1wll.py
@@ -1,0 +1,182 @@
+"""Quirk for Double Digital Meter (product_id dhto3y4uachr1wll).
+
+A two-channel DIN-rail current-transformer meter. Each channel reports its
+own voltage, current, power and energy totals, plus a combined energy total
+for both channels.
+
+Tuya advertises no datapoints at all for this product: `function`,
+`status_range` and `local_strategy` all come back empty, so Home Assistant
+builds no entities and marks the device unsupported. Because the device is
+`support_local`, an empty `local_strategy` also means the SDK drops every
+incoming dpId report, which is why `status` stays empty as well.
+
+The datapoint definitions below were taken from a diagnostics capture of the
+same product_id in https://github.com/azerty9971/xtend_tuya/issues/990, and
+the scales are confirmed against the physical device.
+
+The device reports 24 datapoints in total (dpId 101-124). This quirk declares
+the 15 that map to Home Assistant entities; the remaining 9 (`sync_request`,
+`sync_response`, `add_ele1` / `add_ele2`, `today_energy_add1` /
+`today_energy_add2`, `power_type1` / `power_type2` and `net_state`) are left
+for a follow-up. The four `add_ele*` / `today_energy_add*` datapoints are
+per-report increments rather than running totals -- the cloud's report-type
+endpoint returns them with `report_type: sum` -- so `total_energy1` /
+`total_energy2` are the cumulative counters used here.
+
+See https://github.com/home-assistant/core/issues/176755.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="dhto3y4uachr1wll")
+    # Channel 1
+    .add_dpid_enum(
+        dpid=103,
+        dpcode="device_state1",
+        dpmode=DPMode.READ,
+        enum_range=["close", "monitor", "working", "warning"],
+    )
+    .add_dpid_integer(
+        dpid=105,
+        dpcode="cur_power1",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=2000000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=106,
+        dpcode="cur_current1",
+        dpmode=DPMode.READ,
+        unit="A",
+        min=0,
+        max=800000,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=107,
+        dpcode="cur_voltage1",
+        dpmode=DPMode.READ,
+        unit="V",
+        min=0,
+        max=5000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=108,
+        dpcode="total_energy1",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=2147483647,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=109,
+        dpcode="today_acc_energy1",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=2147483647,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=111,
+        dpcode="warn_power1",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="W",
+        min=200,
+        max=50000,
+        scale=0,
+        step=100,
+    )
+    # Channel 2
+    .add_dpid_enum(
+        dpid=113,
+        dpcode="device_state2",
+        dpmode=DPMode.READ,
+        enum_range=["idle", "monitor", "working", "warning"],
+    )
+    .add_dpid_integer(
+        dpid=115,
+        dpcode="cur_power2",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=2000000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=116,
+        dpcode="cur_current2",
+        dpmode=DPMode.READ,
+        unit="A",
+        min=0,
+        max=800000,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=117,
+        dpcode="cur_voltage2",
+        dpmode=DPMode.READ,
+        unit="V",
+        min=0,
+        max=5000,
+        scale=1,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=118,
+        dpcode="total_energy2",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=2147483647,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=119,
+        dpcode="today_acc_energy2",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=2147483647,
+        scale=3,
+        step=1,
+    )
+    .add_dpid_integer(
+        dpid=121,
+        dpcode="warn_power2",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="W",
+        min=200,
+        max=50000,
+        scale=0,
+        step=100,
+    )
+    # Both channels combined
+    .add_dpid_integer(
+        dpid=123,
+        dpcode="all_energy",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=2147483647,
+        scale=3,
+        step=1,
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/cz/test_dhto3y4uachr1wll.py
+++ b/tests/devices/cz/test_dhto3y4uachr1wll.py
@@ -1,0 +1,122 @@
+"""Test device-level quirk initialisation."""
+
+import json
+
+from tests import create_device
+from tuya_device_handlers.registry import QuirksRegistry
+
+_CHANNEL_DPCODES = (
+    "device_state{n}",
+    "cur_power{n}",
+    "cur_current{n}",
+    "cur_voltage{n}",
+    "total_energy{n}",
+    "today_acc_energy{n}",
+    "warn_power{n}",
+)
+
+_CHANNEL_1_DPIDS = (103, 105, 106, 107, 108, 109, 111)
+_CHANNEL_2_DPIDS = (113, 115, 116, 117, 118, 119, 121)
+_ALL_ENERGY_DPID = 123
+
+
+def test_quirk_supplies_the_datapoints(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Tuya advertises nothing, so the quirk supplies the datapoints."""
+    device = create_device("cz_dhto3y4uachr1wll.json")
+
+    assert device.status_range == {}
+    assert device.function == {}
+    assert device.local_strategy == {}
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    for channel in (1, 2):
+        for dpcode in _CHANNEL_DPCODES:
+            assert dpcode.format(n=channel) in device.status_range
+
+    assert "all_energy" in device.status_range
+
+    # Only the two power warning thresholds are writable, so they are the
+    # only entries in `function`.
+    assert set(device.function) == {"warn_power1", "warn_power2"}
+
+
+def test_local_strategy_maps_dpids(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """The device is local, so dpId reports must resolve to a status code."""
+    device = create_device("cz_dhto3y4uachr1wll.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    # Without these entries the sharing SDK discards every dpId report.
+    assert device.local_strategy[105]["status_code"] == "cur_power1"
+    assert device.local_strategy[115]["status_code"] == "cur_power2"
+    assert device.local_strategy[123]["status_code"] == "all_energy"
+    assert sorted(device.local_strategy) == [
+        *_CHANNEL_1_DPIDS,
+        *_CHANNEL_2_DPIDS,
+        _ALL_ENERGY_DPID,
+    ]
+
+
+def test_electricity_scaling(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Both channels report deci-volt, milli-amp and deci-watt."""
+    device = create_device("cz_dhto3y4uachr1wll.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    for channel in (1, 2):
+        voltage = json.loads(
+            device.status_range[f"cur_voltage{channel}"].values
+        )
+        assert voltage["unit"] == "V"
+        assert voltage["scale"] == 1
+
+        current = json.loads(
+            device.status_range[f"cur_current{channel}"].values
+        )
+        assert current["unit"] == "A"
+        assert current["scale"] == 3
+
+        power = json.loads(device.status_range[f"cur_power{channel}"].values)
+        assert power["unit"] == "W"
+        assert power["scale"] == 1
+
+        total = json.loads(device.status_range[f"total_energy{channel}"].values)
+        assert total["unit"] == "kWh"
+        assert total["scale"] == 3
+
+
+def test_energy_totals_are_cumulative(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """The energy counters are running totals, not per-report increments."""
+    device = create_device("cz_dhto3y4uachr1wll.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    for dpcode in ("total_energy1", "total_energy2", "all_energy"):
+        assert device.status_range[dpcode].report_type is None
+
+
+def test_device_state_enum_ranges_differ_per_channel(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Channel 1 reports `close` where channel 2 reports `idle`."""
+    device = create_device("cz_dhto3y4uachr1wll.json")
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert json.loads(device.status_range["device_state1"].values)["range"] == [
+        "close",
+        "monitor",
+        "working",
+        "warning",
+    ]
+    assert json.loads(device.status_range["device_state2"].values)["range"] == [
+        "idle",
+        "monitor",
+        "working",
+        "warning",
+    ]

--- a/tests/fixtures/devices/cz_dhto3y4uachr1wll.json
+++ b/tests/fixtures/devices/cz_dhto3y4uachr1wll.json
@@ -1,0 +1,22 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Double Digital Meter",
+  "category": "cz",
+  "product_id": "dhto3y4uachr1wll",
+  "product_name": "Double Digital Meter",
+  "online": true,
+  "sub": false,
+  "time_zone": "+09:30",
+  "active_time": "2026-08-07T00:16:29+00:00",
+  "create_time": "2026-08-07T00:16:29+00:00",
+  "update_time": "2026-08-07T00:16:29+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "local_strategy": {},
+  "set_up": false,
+  "support_local": true
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

I recently bought a Tuya capable smart sensor (2 Channel DIN Rail CT Energy Meter) for monitoring power consumption, however it was 'unsupported' in Home Assistant. The reason is that Tuya advertises no datapoints for this product at all (specifications and the status endpoint both come back empty), so HA builds no entities and marks the device unsupported. Because the device is support_local, the empty local_strategy also makes the sharing SDK drop every incoming dpId report, so status stays empty too.

To fix this I created a quirk file (category cz, product_id dhto3y4uachr1wll). The 24 datapoint definitions (dpId 101–124) come from a diagnostics capture of the same product_id in azerty9971/xtend_tuya#990. Four of them (add_ele1, add_ele2, today_energy_add1, today_energy_add2) are declared as sums because the cloud's report-type endpoint returns them as report_type: sum ... they're per-report increments, while total_energy1 / total_energy2 are the cumulative counters.


## Test plan

I have this installed on my HA instance and have verified that with the quirk installed status_range and local_strategy populate with 24 entries, the device subscribes to MQTT, and readings decode correctly.  This involved installing the quirk at /config/tuya_quirks/, watching the diagnostics go from 0 → 24 datapoints with local_strategy populated, the device subscribed to MQTT, readings decoded.  For example my AC unit cold-start ramp 22 W → 919 W → 2411 W at 0.978 → 10.459 A, and the device's combined all_energy counter equals the sum of both channels exactly.

## Related issue
home-assistant/core#176755 (same product family, 79a7z01v3n35kytb)
