### PR TITLE
Add quirk for Eeese Otto dehumidifier (cs_ma3oq4onxxwg91ky)

### DIFF
--- a/src/tuya_device_handlers/devices/cs/cs_ma3oq4onxxwg91ky.py
+++ b/src/tuya_device_handlers/devices/cs/cs_ma3oq4onxxwg91ky.py
@@ -1,0 +1,19 @@
+"""Quirk for Eeese Otto dehumidifier. Adds Tank Full information."""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="ma3oq4onxxwg91ky",
+    )
+    .add_dpid_bitmap(
+        dpid=19,
+        dpcode="fault",
+        dpmode=DPMode.READ,
+        label_range=["E1", "E2", "tankfull"],
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/cs/test_ma3oq4onxxwg91ky.py
+++ b/tests/devices/cs/test_ma3oq4onxxwg91ky.py
@@ -1,0 +1,41 @@
+"""Test device-level quirk initialisation for CS devices."""
+
+import json
+
+from tests import create_device
+from tests.integration_helpers.binary_sensor import (
+    get_binary_sensor_default_definitions,
+)
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Eeese Otto extends the fault bitmap with the tankfull label."""
+    device = create_device("cs_ma3oq4onxxwg91ky.json")
+
+    assert json.loads(device.status_range["fault"].values) == {
+        "label": ["E1", "E2"]
+    }
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert json.loads(device.status_range["fault"].values) == {
+        "label": ["E1", "E2", "tankfull"]
+    }
+
+
+def test_default_definitions(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Eeese Otto exposes a tank full binary sensor."""
+    device = create_device("cs_ma3oq4onxxwg91ky.json")
+
+    definitions = get_binary_sensor_default_definitions(device)
+    assert "tankfull" not in definitions
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    definitions = get_binary_sensor_default_definitions(device)
+    assert "tankfull" in definitions

--- a/tests/fixtures/devices/cs_ma3oq4onxxwg91ky.json
+++ b/tests/fixtures/devices/cs_ma3oq4onxxwg91ky.json
@@ -1,0 +1,347 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Otto Dehumidifier",
+  "category": "cs",
+  "product_id": "ma3oq4onxxwg91ky",
+  "product_name": "",
+  "online": true,
+  "sub": false,
+  "time_zone": "+02:00",
+  "active_time": "2026-08-27T05:05:12+00:00",
+  "create_time": "2026-08-27T05:05:12+00:00",
+  "update_time": "2026-08-27T05:05:12+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}"
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}"
+    }
+  },
+  "local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "dehumidify_set_value",
+      "config_item": {
+        "statusFormat": "{\"dehumidify_set_value\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "humidity_indoor",
+      "config_item": {
+        "statusFormat": "{\"humidity_indoor\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "8": {
+      "value_convert": "default",
+      "status_code": "swing",
+      "config_item": {
+        "statusFormat": "{\"swing\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "10": {
+      "value_convert": "default",
+      "status_code": "anion",
+      "config_item": {
+        "statusFormat": "{\"anion\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "child_lock",
+      "config_item": {
+        "statusFormat": "{\"child_lock\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "17": {
+      "value_convert": "default",
+      "status_code": "countdown_set",
+      "config_item": {
+        "statusFormat": "{\"countdown_set\":\"$\"}",
+        "valueDesc": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "fault",
+      "config_item": {
+        "statusFormat": "{\"fault\": \"$\"}",
+        "valueDesc": "{\"label\": [\"E1\", \"E2\", \"tankfull\"]}",
+        "valueType": "Bitmap",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}",
+      "report_type": null
+    },
+    "humidity_indoor": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}",
+      "report_type": null
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": "{\"label\": [\"E1\", \"E2\", \"tankfull\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": true,
+    "dehumidify_set_value": 45,
+    "humidity_indoor": 46,
+    "swing": false,
+    "anion": false,
+    "child_lock": false,
+    "countdown_set": "cancel",
+    "fault": 0
+  },
+  "set_up": true,
+  "support_local": true,
+  "quirk": "/config/tuya_quirks/cs_ma3oq4onxxwg91ky.py:8",
+  "warnings": null,
+  "original_category": "cs",
+  "original_function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}"
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}"
+    }
+  },
+  "original_local_strategy": {
+    "1": {
+      "value_convert": "default",
+      "status_code": "switch",
+      "config_item": {
+        "statusFormat": "{\"switch\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "2": {
+      "value_convert": "default",
+      "status_code": "dehumidify_set_value",
+      "config_item": {
+        "statusFormat": "{\"dehumidify_set_value\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "6": {
+      "value_convert": "default",
+      "status_code": "humidity_indoor",
+      "config_item": {
+        "statusFormat": "{\"humidity_indoor\":\"$\"}",
+        "valueDesc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "8": {
+      "value_convert": "default",
+      "status_code": "swing",
+      "config_item": {
+        "statusFormat": "{\"swing\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "10": {
+      "value_convert": "default",
+      "status_code": "anion",
+      "config_item": {
+        "statusFormat": "{\"anion\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "16": {
+      "value_convert": "default",
+      "status_code": "child_lock",
+      "config_item": {
+        "statusFormat": "{\"child_lock\":\"$\"}",
+        "valueDesc": "{}",
+        "valueType": "Boolean",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "17": {
+      "value_convert": "default",
+      "status_code": "countdown_set",
+      "config_item": {
+        "statusFormat": "{\"countdown_set\":\"$\"}",
+        "valueDesc": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}",
+        "valueType": "Enum",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    },
+    "19": {
+      "value_convert": "default",
+      "status_code": "fault",
+      "config_item": {
+        "statusFormat": "{\"fault\":\"$\"}",
+        "valueDesc": "{\"label\":[\"E1\",\"E2\"]}",
+        "valueType": "Bitmap",
+        "enumMappingMap": {},
+        "pid": "ma3oq4onxxwg91ky"
+      }
+    }
+  },
+  "original_status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":25,\"max\":80,\"scale\":0,\"step\":5}",
+      "report_type": null
+    },
+    "humidity_indoor": {
+      "type": "Integer",
+      "value": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
+      "report_type": null
+    },
+    "swing": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": "{\"range\":[\"cancel\",\"1h\",\"2h\",\"3h\"]}",
+      "report_type": null
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": "{\"label\":[\"E1\",\"E2\"]}",
+      "report_type": null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a quirk for the Eeese Otto dehumidifier (`cs_ma3oq4onxxwg91ky`).

The device reports faults on DP 19 as a bitmap, but only bits 0 and 1 are labelled (`E1`, `E2`). Tank full is bit 2, so HA never created a tank-full sensor. The quirk adds `tankfull` as the bit 2 label, which gives the standard `cs` tank-full binary sensor.

## Test plan

- New test + device fixture under `tests/devices/cs/`: checks the fault labels before/after quirk init, and that a `tankfull` binary sensor definition only exists after.
- Full suite passes, ruff clean.
- Ran it as a custom quirk on my own device in HA: tank-full sensor works.

## Related issue
Related: https://github.com/home-assistant/core/issues/142995