### PR TITLE
Add map_dpid_initial_status_values to DeviceQuirk

### DIFF
--- a/src/tuya_device_handlers/builder/device_quirk.py
+++ b/src/tuya_device_handlers/builder/device_quirk.py
@@ -20,7 +20,7 @@ from tuya_device_handlers.type_information import TypeInformation
 
 
 @dataclass(kw_only=True)
-class QuirkEntry(ABC):
+class _QuirkEntry(ABC):
     """Base for an entry that a quirk applies to a device.
 
     When `apply_when` is set, the entry is only applied to devices for
@@ -50,7 +50,7 @@ class QuirkEntry(ABC):
 
 
 @dataclass(kw_only=True)
-class LocalConvertStrategy(QuirkEntry):
+class _LocalConvertStrategy(_QuirkEntry):
     """Definition for a local convert strategy."""
 
     requires_local_support: ClassVar[bool] = True
@@ -83,7 +83,7 @@ class LocalConvertStrategy(QuirkEntry):
 
 
 @dataclass(kw_only=True)
-class LocalStrategyRemoval(QuirkEntry):
+class _LocalStrategyRemoval(_QuirkEntry):
     """Removal of a local convert strategy."""
 
     requires_local_support: ClassVar[bool] = True
@@ -94,7 +94,7 @@ class LocalStrategyRemoval(QuirkEntry):
 
 
 @dataclass(kw_only=True)
-class DatapointRemoval(QuirkEntry):
+class _DatapointRemoval(_QuirkEntry):
     """Removal of a Tuya datapoint."""
 
     def apply(self, device: CustomerDevice) -> None:
@@ -106,7 +106,29 @@ class DatapointRemoval(QuirkEntry):
 
 
 @dataclass(kw_only=True)
-class DatapointDefinition(QuirkEntry):
+class _InitialStatusValueMapping(_QuirkEntry):
+    """Mapping applied to the initial status value of a datapoint.
+
+    The cloud may report the cached status of a datapoint in a different
+    shape than the values reported later over MQTT (for example the
+    strings ``"true"``/``"false"`` for a Boolean datapoint). This entry
+    rewrites the initial value so it matches the expected type.
+    """
+
+    status_mapping: dict[Any, Any]
+
+    def apply(self, device: CustomerDevice) -> None:
+        """Map the initial status value on the device."""
+        raw_value = device.status.get(self.dpcode)
+        try:
+            if raw_value in self.status_mapping:
+                device.status[self.dpcode] = self.status_mapping[raw_value]
+        except TypeError:  # unhashable raw value
+            pass
+
+
+@dataclass(kw_only=True)
+class _DatapointDefinition(_QuirkEntry):
     """Definition for a Tuya datapoint."""
 
     dpmode: DPMode
@@ -168,7 +190,7 @@ class DatapointDefinition(QuirkEntry):
 class DeviceQuirk(DeviceQuirkProtocol):
     """Quirk for Tuya device."""
 
-    _quirk_entries: list[QuirkEntry]
+    _quirk_entries: list[_QuirkEntry]
     _type_information_overrides: dict[
         tuple[int, str], type[TypeInformation[Any]]
     ]
@@ -216,7 +238,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
             device.category = self._override_category
 
         # Entries are applied in the order the builder methods were called.
-        # A LocalConvertStrategy reads device.status_range, so it must be
+        # A _LocalConvertStrategy reads device.status_range, so it must be
         # added after the datapoint definition that provides its dpcode.
         for entry in self._quirk_entries:
             if entry.applies_to_device(device):
@@ -263,7 +285,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Add datapoint Bitmap definition."""
         self._quirk_entries.append(
-            DatapointDefinition(
+            _DatapointDefinition(
                 dpid=dpid,
                 dpcode=dpcode,
                 dpmode=dpmode,
@@ -284,7 +306,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Add datapoint Boolean definition."""
         self._quirk_entries.append(
-            DatapointDefinition(
+            _DatapointDefinition(
                 dpid=dpid,
                 dpcode=dpcode,
                 dpmode=dpmode,
@@ -306,7 +328,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Add datapoint Enum definition."""
         self._quirk_entries.append(
-            DatapointDefinition(
+            _DatapointDefinition(
                 dpid=dpid,
                 dpcode=dpcode,
                 dpmode=dpmode,
@@ -333,7 +355,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Add datapoint Integer definition."""
         self._quirk_entries.append(
-            DatapointDefinition(
+            _DatapointDefinition(
                 dpid=dpid,
                 dpcode=dpcode,
                 dpmode=dpmode,
@@ -348,6 +370,25 @@ class DeviceQuirk(DeviceQuirkProtocol):
                         "step": step,
                     }
                 ),
+                apply_when=apply_when,
+            )
+        )
+        return self
+
+    def map_dpid_initial_status_values(
+        self,
+        *,
+        dpid: int,
+        dpcode: str,
+        status_mapping: dict[Any, Any],
+        apply_when: Callable[[CustomerDevice], bool] | None = None,
+    ) -> Self:
+        """Map the initial status value of a datapoint."""
+        self._quirk_entries.append(
+            _InitialStatusValueMapping(
+                dpid=dpid,
+                dpcode=dpcode,
+                status_mapping=status_mapping,
                 apply_when=apply_when,
             )
         )
@@ -373,7 +414,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Remove datapoint definition."""
         self._quirk_entries.append(
-            DatapointRemoval(dpid=dpid, dpcode=dpcode, apply_when=apply_when)
+            _DatapointRemoval(dpid=dpid, dpcode=dpcode, apply_when=apply_when)
         )
         return self
 
@@ -387,7 +428,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Override local strategy for a datapoint."""
         self._quirk_entries.append(
-            LocalConvertStrategy(
+            _LocalConvertStrategy(
                 dpid=dpid,
                 dpcode=dpcode,
                 value_convert="enum",
@@ -409,7 +450,7 @@ class DeviceQuirk(DeviceQuirkProtocol):
     ) -> Self:
         """Remove datapoint strategy."""
         self._quirk_entries.append(
-            LocalStrategyRemoval(
+            _LocalStrategyRemoval(
                 dpid=dpid, dpcode=dpcode, apply_when=apply_when
             )
         )

--- a/tests/builder/test_device_quirk.py
+++ b/tests/builder/test_device_quirk.py
@@ -1,8 +1,9 @@
-"""Tests for DatapointDefinition and DeviceQuirk."""
+"""Tests for _DatapointDefinition and DeviceQuirk."""
 
 from collections.abc import Callable
 import json
 import pathlib
+from typing import Any
 
 import pytest
 from tuya_sharing import (
@@ -13,12 +14,12 @@ from tuya_sharing import (
 )
 
 from tuya_device_handlers.builder.device_quirk import (
-    DatapointDefinition,
-    DatapointRemoval,
     DeviceQuirk,
-    LocalConvertStrategy,
-    LocalStrategyRemoval,
-    QuirkEntry,
+    _DatapointDefinition,
+    _DatapointRemoval,
+    _LocalConvertStrategy,
+    _LocalStrategyRemoval,
+    _QuirkEntry,
 )
 from tuya_device_handlers.const import DPMode, DPType
 from tuya_device_handlers.registry import QuirksRegistry
@@ -32,7 +33,7 @@ from tuya_device_handlers.type_information import (
 
 def test_datapoint_definition_to_function() -> None:
     """to_function builds a DeviceFunction from the definition."""
-    definition = DatapointDefinition(
+    definition = _DatapointDefinition(
         dpid=1,
         dpcode="x",
         dpmode=DPMode.READ | DPMode.WRITE,
@@ -47,7 +48,7 @@ def test_datapoint_definition_to_function() -> None:
 
 def test_datapoint_definition_to_local_strategy() -> None:
     """to_local_strategy builds the LocalStrategy dict for the device."""
-    definition = DatapointDefinition(
+    definition = _DatapointDefinition(
         dpid=2,
         dpcode="y",
         dpmode=DPMode.READ,
@@ -63,7 +64,7 @@ def test_datapoint_definition_to_local_strategy() -> None:
 
 def test_datapoint_definition_to_status_range() -> None:
     """to_status_range builds a DeviceStatusRange from the definition."""
-    definition = DatapointDefinition(
+    definition = _DatapointDefinition(
         dpid=3,
         dpcode="z",
         dpmode=DPMode.READ,
@@ -79,7 +80,7 @@ def test_datapoint_definition_to_status_range() -> None:
 
 def test_datapoint_definition_to_status_range_report_type() -> None:
     """to_status_range carries the report_type to the DeviceStatusRange."""
-    definition = DatapointDefinition(
+    definition = _DatapointDefinition(
         dpid=4,
         dpcode="energy",
         dpmode=DPMode.READ,
@@ -107,7 +108,7 @@ def test_add_dpid_bitmap() -> None:
         dpid=1, dpcode="bm", dpmode=DPMode.READ, label_range=["a", "b"]
     )
     definition = quirk._quirk_entries[0]
-    assert isinstance(definition, DatapointDefinition)
+    assert isinstance(definition, _DatapointDefinition)
     assert definition.dptype is DPType.BITMAP
     assert json.loads(definition.values or "")["label"] == ["a", "b"]
 
@@ -118,7 +119,7 @@ def test_add_dpid_boolean() -> None:
         dpid=2, dpcode="bo", dpmode=DPMode.WRITE
     )
     definition = quirk._quirk_entries[0]
-    assert isinstance(definition, DatapointDefinition)
+    assert isinstance(definition, _DatapointDefinition)
     assert definition.dptype is DPType.BOOLEAN
 
 
@@ -128,7 +129,7 @@ def test_add_dpid_enum() -> None:
         dpid=3, dpcode="en", dpmode=DPMode.READ, enum_range=["scene", "auto"]
     )
     definition = quirk._quirk_entries[0]
-    assert isinstance(definition, DatapointDefinition)
+    assert isinstance(definition, _DatapointDefinition)
     assert definition.dptype is DPType.ENUM
     assert json.loads(definition.values or "")["range"] == ["scene", "auto"]
 
@@ -147,7 +148,7 @@ def test_add_dpid_integer() -> None:
         report_type="sum",
     )
     definition = quirk._quirk_entries[0]
-    assert isinstance(definition, DatapointDefinition)
+    assert isinstance(definition, _DatapointDefinition)
     assert definition.dptype is DPType.INTEGER
     assert definition.report_type == "sum"
     payload = json.loads(definition.values or "")
@@ -158,7 +159,7 @@ def test_remove_dpid() -> None:
     """remove_dpid stores a removal entry for the dpid."""
     quirk = DeviceQuirk().remove_dpid(dpid=5, dpcode="rm")
     entry = quirk._quirk_entries[0]
-    assert isinstance(entry, DatapointRemoval)
+    assert isinstance(entry, _DatapointRemoval)
     assert entry.dpid == 5
     assert entry.dpcode == "rm"
 
@@ -170,14 +171,14 @@ def test_override_category() -> None:
 
 
 def test_set_dpid_strategy_to_enum() -> None:
-    """set_dpid_strategy_to_enum stores an enum LocalConvertStrategy."""
+    """set_dpid_strategy_to_enum stores an enum _LocalConvertStrategy."""
     quirk = DeviceQuirk().set_dpid_strategy_to_enum(
         dpid=1,
         dpcode="x",
         enum_mapping_map={"on": True, "off": False},
     )
     strategy = quirk._quirk_entries[0]
-    assert isinstance(strategy, LocalConvertStrategy)
+    assert isinstance(strategy, _LocalConvertStrategy)
     assert strategy.value_convert == "enum"
     assert strategy.enum_mapping_map == {
         "on": {"value": True},
@@ -189,7 +190,7 @@ def test_remove_dpid_strategy() -> None:
     """remove_dpid_strategy stores a removal entry for the strategy."""
     quirk = DeviceQuirk().remove_dpid_strategy(dpid=2, dpcode="y")
     entry = quirk._quirk_entries[0]
-    assert isinstance(entry, LocalStrategyRemoval)
+    assert isinstance(entry, _LocalStrategyRemoval)
     assert entry.dpid == 2
     assert entry.dpcode == "y"
 
@@ -373,13 +374,13 @@ def test_initialise_device_local_strategy_apply_when_not_met(
                 enum_mapping_map={"on": True},
                 apply_when=apply_when,
             ),
-            LocalConvertStrategy,
+            _LocalConvertStrategy,
         ),
         (
             lambda quirk, apply_when: quirk.remove_dpid_strategy(
                 dpid=1, dpcode="x", apply_when=apply_when
             ),
-            LocalStrategyRemoval,
+            _LocalStrategyRemoval,
         ),
     ],
     ids=["set_dpid_strategy_to_enum", "remove_dpid_strategy"],
@@ -388,7 +389,7 @@ def test_local_strategy_apply_when_is_stored(
     add_entry: Callable[
         [DeviceQuirk, Callable[[CustomerDevice], bool]], DeviceQuirk
     ],
-    expected_entry_type: type[QuirkEntry],
+    expected_entry_type: type[_QuirkEntry],
 ) -> None:
     """The builder methods forward apply_when onto the stored entry."""
 
@@ -461,6 +462,57 @@ def test_initialise_device_remove_dpid_removes_everything(
     assert 7 not in mock_device.local_strategy
     assert "g" not in mock_device.status
     assert "g" not in mock_device.status_range
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        pytest.param("true", True, id="true-string"),
+        pytest.param("false", False, id="false-string"),
+        pytest.param(True, True, id="native-true"),
+        pytest.param("other", "other", id="unmapped"),
+        pytest.param(["unhashable"], ["unhashable"], id="unhashable"),
+    ],
+)
+def test_initialise_device_map_dpid_initial_status_values(
+    mock_device: CustomerDevice,
+    raw_value: Any,
+    expected: Any,
+) -> None:
+    """map_dpid_initial_status_values rewrites only mapped initial values."""
+    mock_device.status["x"] = raw_value
+    quirk = DeviceQuirk().map_dpid_initial_status_values(
+        dpid=1, dpcode="x", status_mapping={"true": True, "false": False}
+    )
+    quirk.initialise_device(mock_device)
+    assert mock_device.status["x"] == expected
+
+
+def test_initialise_device_map_dpid_initial_status_values_missing_dpcode(
+    mock_device: CustomerDevice,
+) -> None:
+    """An absent dpcode is left absent."""
+    mock_device.status.pop("x", None)
+    quirk = DeviceQuirk().map_dpid_initial_status_values(
+        dpid=1, dpcode="x", status_mapping={"true": True}
+    )
+    quirk.initialise_device(mock_device)
+    assert "x" not in mock_device.status
+
+
+def test_initialise_device_map_dpid_initial_status_values_apply_when_not_met(
+    mock_device: CustomerDevice,
+) -> None:
+    """A status mapping whose apply_when returns False is skipped."""
+    mock_device.status["x"] = "true"
+    quirk = DeviceQuirk().map_dpid_initial_status_values(
+        dpid=1,
+        dpcode="x",
+        status_mapping={"true": True},
+        apply_when=lambda _: False,
+    )
+    quirk.initialise_device(mock_device)
+    assert mock_device.status["x"] == "true"
 
 
 def test_initialise_device_apply_when_met(


### PR DESCRIPTION
<!--
  Thank you for contributing to tuya-device-handlers!
  Please fill in the sections below to help us review your PR.
-->

## Summary

<!-- What does this PR do, and why? -->

As described by @gzeel in #452, the initial status values can be formatted incorrectly.
This adds a path to re-format the initial values correctly.

## Test plan

<!-- How was it tested? -->

## Related issue

<!-- Use "Fixes #123" to auto-close the related issue. -->
