### PR TITLE
Expose min/max kelvin in ColorTempWrapper

### DIFF
--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -1,7 +1,7 @@
 """Tuya device wrapper."""
 
 import json
-from typing import Any
+from typing import Any, ClassVar
 
 from tuya_sharing import CustomerDevice
 
@@ -140,11 +140,20 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
 
     A round-trip from Tuya range to Kelvin via Mireds is done for
     historical reason, and because mired scale is a better measure
-    of perceptual color difference
+    of perceptual color difference.
+
+    `min_kelvin` / `max_kelvin` describe the color temperature range the
+    lamp actually covers. The Tuya cloud never reports it, so they
+    default to the range assumed for all Tuya lights; a subclass may
+    override them for a device that deviates. The host integration reads
+    them to report the entity's supported range.
     """
 
-    MIN_KELVIN = 2000  # 500 mireds
-    MAX_KELVIN = 6500  # 153 mireds
+    MIN_KELVIN: ClassVar[int] = 2000  # 500 mireds
+    MAX_KELVIN: ClassVar[int] = 6500  # 153 mireds
+
+    min_kelvin: int = MIN_KELVIN
+    max_kelvin: int = MAX_KELVIN
 
     @staticmethod
     def kelvin_to_mired(kelvin: int) -> float:
@@ -161,8 +170,8 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
     ) -> None:
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
-        max_mireds = self.kelvin_to_mired(self.MIN_KELVIN)
-        min_mireds = self.kelvin_to_mired(self.MAX_KELVIN)
+        max_mireds = self.kelvin_to_mired(self.min_kelvin)
+        min_mireds = self.kelvin_to_mired(self.max_kelvin)
         self._remap_helper = RemapHelper.from_type_information(
             type_information, min_mireds, max_mireds
         )

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -431,3 +431,39 @@ def test_color_data_string_action_command(
 
     assert wrapper
     assert wrapper.get_update_commands(mock_device, action) == expected
+
+
+def test_color_temp_wrapper_default_kelvin_range(
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the default color temperature range of a light."""
+    _inject_default_light(mock_device)
+    wrapper = ColorTempWrapper.find_dpcode(mock_device, "temp_value")
+
+    assert wrapper
+    assert wrapper.min_kelvin == 2000
+    assert wrapper.max_kelvin == 6500
+
+
+def test_color_temp_wrapper_custom_kelvin_range(
+    mock_device: CustomerDevice,
+) -> None:
+    """Test a subclass overriding the color temperature range."""
+
+    class CustomColorTempWrapper(ColorTempWrapper):
+        """Wrapper for a 1600-4000 K lamp."""
+
+        min_kelvin = 1600
+        max_kelvin = 4000
+
+    _inject_default_light(mock_device)
+    mock_device.status["temp_value"] = 795
+    wrapper = CustomColorTempWrapper.find_dpcode(mock_device, "temp_value")
+
+    assert wrapper
+    assert wrapper.min_kelvin == 1600
+    assert wrapper.max_kelvin == 4000
+    assert wrapper.read_device_status(mock_device) == 3059
+    assert wrapper.get_update_commands(mock_device, 4000) == [
+        {"code": "temp_value", "value": 1000}
+    ]


### PR DESCRIPTION
## Summary

Make the color temperature range a property of `ColorTempWrapper` rather
than a pair of hardcoded constants, so it can be overridden per device
and read by the host integration.

- `MIN_KELVIN` / `MAX_KELVIN` become `ClassVar[int]`
- `min_kelvin` / `max_kelvin` are added, defaulting to those constants
- `__init__` builds the mired remap from `self.min_kelvin` /
  `self.max_kelvin` instead of the constants

Behaviour is unchanged for every existing device: nothing overrides the
defaults yet.

## Why

The Tuya cloud never reports the Kelvin range a lamp actually covers,
only the raw datapoint range (typically 0-1000), so we assume 2000-6500 K
for all lights. Some devices deviate — see
home-assistant/core#166103, a bulb whose physical range is 1600-4000 K —
and Home Assistant currently shows the wrong slider for them, since
`TuyaLightEntity` hardcodes:

```python
_attr_min_color_temp_kelvin = 2000  # 500 Mireds
_attr_max_color_temp_kelvin = 6500  # 153 Mireds
```

This is the first of four steps:

1. **this PR** — expose the range on the wrapper
2. core — read `min_kelvin` / `max_kelvin` from the wrapper for
   `_attr_min/max_color_temp_kelvin`, falling back to the current
   constants (needs a release of this and a pin bump)
3. this repo — let a quirk set the values per datapoint
4. this repo — the quirk for the device in the issue above

Splitting it this way keeps the core-facing surface minimal and lets the
core change start early, since it gates on a release.

## Tests

Two tests: one pinning the defaults, one subclassing with a 1600-4000 K
range to show an override flows through both directions of the
conversion. The subclass is the only override mechanism at this point —
selecting one from a quirk comes in step 3.