### PR TITLE
Add color temperature scale to ColorTempWrapper

### DIFF
--- a/src/tuya_device_handlers/const.py
+++ b/src/tuya_device_handlers/const.py
@@ -13,6 +13,16 @@ CELSIUS_ALIASES = {"°c", "c", "celsius", "℃"}
 FAHRENHEIT_ALIASES = {"°f", "f", "fahrenheit", "℉"}
 
 
+class ColorTempScale(StrEnum):
+    """Scale used by a device for its color temperature datapoint."""
+
+    MIRED = "mired"
+    """The raw range maps linearly onto mireds (Tuya default)."""
+
+    KELVIN = "kelvin"
+    """The raw range maps linearly onto Kelvin."""
+
+
 class DPMode(IntFlag):
     """Data point modes."""
 

--- a/src/tuya_device_handlers/device_wrapper/light.py
+++ b/src/tuya_device_handlers/device_wrapper/light.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 
 from tuya_sharing import CustomerDevice
 
+from tuya_device_handlers.const import ColorTempScale
 from tuya_device_handlers.type_information import IntegerTypeInformation
 from tuya_device_handlers.utils import RemapHelper
 
@@ -147,6 +148,12 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
     default to the range assumed for all Tuya lights; a subclass may
     override them for a device that deviates. The host integration reads
     them to report the entity's supported range.
+
+    `color_temp_scale` tells how the raw range maps onto that Kelvin
+    range. Tuya lights are assumed to be linear in mireds; a subclass may
+    select `ColorTempScale.KELVIN` for a device that is linear in Kelvin
+    instead. It only affects the conversion done here, the host
+    integration always deals in Kelvin.
     """
 
     MIN_KELVIN: ClassVar[int] = 2000  # 500 mireds
@@ -154,6 +161,7 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
 
     min_kelvin: int = MIN_KELVIN
     max_kelvin: int = MAX_KELVIN
+    color_temp_scale: ColorTempScale = ColorTempScale.MIRED
 
     @staticmethod
     def kelvin_to_mired(kelvin: int) -> float:
@@ -170,16 +178,24 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
     ) -> None:
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
-        max_mireds = self.kelvin_to_mired(self.min_kelvin)
-        min_mireds = self.kelvin_to_mired(self.max_kelvin)
-        self._remap_helper = RemapHelper.from_type_information(
-            type_information, min_mireds, max_mireds
-        )
+        if self.color_temp_scale is ColorTempScale.KELVIN:
+            self._remap_helper = RemapHelper.from_type_information(
+                type_information, self.min_kelvin, self.max_kelvin
+            )
+        else:
+            max_mireds = self.kelvin_to_mired(self.min_kelvin)
+            min_mireds = self.kelvin_to_mired(self.max_kelvin)
+            self._remap_helper = RemapHelper.from_type_information(
+                type_information, min_mireds, max_mireds
+            )
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Return the color temperature value in Kelvin."""
         if (temperature := self._read_dpcode_value(device)) is None:
             return None
+
+        if self.color_temp_scale is ColorTempScale.KELVIN:
+            return round(self._remap_helper.remap_value_to(temperature))
 
         return self.mired_to_kelvin(
             self._remap_helper.remap_value_to(temperature, reverse=True)
@@ -189,13 +205,14 @@ class ColorTempWrapper(DPCodeIntegerWrapper[int]):
         self, device: CustomerDevice, value: int
     ) -> Any:
         """Convert HA value (Kelvin) to a raw device value."""
-        return super()._convert_value_to_raw_value(
-            device,
-            self._remap_helper.remap_value_from(
+        if self.color_temp_scale is ColorTempScale.KELVIN:
+            raw_value = self._remap_helper.remap_value_from(value)
+        else:
+            raw_value = self._remap_helper.remap_value_from(
                 self.kelvin_to_mired(value),
                 reverse=True,
-            ),
-        )
+            )
+        return super()._convert_value_to_raw_value(device, raw_value)
 
 
 DEFAULT_H_TYPE = RemapHelper(

--- a/tests/device_wrapper/test_light.py
+++ b/tests/device_wrapper/test_light.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from tuya_sharing import CustomerDevice
 
+from tuya_device_handlers.const import ColorTempScale
 from tuya_device_handlers.device_wrapper.common import (
     DPCodeIntegerWrapper,
     DPCodeTypeInformationWrapper,
@@ -467,3 +468,73 @@ def test_color_temp_wrapper_custom_kelvin_range(
     assert wrapper.get_update_commands(mock_device, 4000) == [
         {"code": "temp_value", "value": 1000}
     ]
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_kelvin"),
+    [
+        (0, 1600),
+        (795, 3508),
+        (1000, 4000),
+    ],
+)
+def test_color_temp_wrapper_kelvin_scale_read(
+    mock_device: CustomerDevice,
+    raw_value: int,
+    expected_kelvin: int,
+) -> None:
+    """Test reading a device whose raw range is linear in Kelvin."""
+
+    class KelvinScaleWrapper(ColorTempWrapper):
+        """Wrapper for a 1600-4000 K lamp, linear in Kelvin."""
+
+        min_kelvin = 1600
+        max_kelvin = 4000
+        color_temp_scale = ColorTempScale.KELVIN
+
+    _inject_default_light(mock_device)
+    mock_device.status["temp_value"] = raw_value
+    wrapper = KelvinScaleWrapper.find_dpcode(mock_device, "temp_value")
+
+    assert wrapper
+    assert wrapper.read_device_status(mock_device) == expected_kelvin
+
+
+@pytest.mark.parametrize(
+    ("kelvin", "expected_raw"),
+    [
+        (1600, 0),
+        (3508, 795),
+        (4000, 1000),
+    ],
+)
+def test_color_temp_wrapper_kelvin_scale_write(
+    mock_device: CustomerDevice,
+    kelvin: int,
+    expected_raw: int,
+) -> None:
+    """Test writing to a device whose raw range is linear in Kelvin."""
+
+    class KelvinScaleWrapper(ColorTempWrapper):
+        """Wrapper for a 1600-4000 K lamp, linear in Kelvin."""
+
+        min_kelvin = 1600
+        max_kelvin = 4000
+        color_temp_scale = ColorTempScale.KELVIN
+
+    _inject_default_light(mock_device)
+    wrapper = KelvinScaleWrapper.find_dpcode(mock_device, "temp_value")
+
+    assert wrapper
+    assert wrapper.get_update_commands(mock_device, kelvin) == [
+        {"code": "temp_value", "value": expected_raw}
+    ]
+
+
+def test_color_temp_wrapper_default_scale(mock_device: CustomerDevice) -> None:
+    """Test the default color temperature scale of a light."""
+    _inject_default_light(mock_device)
+    wrapper = ColorTempWrapper.find_dpcode(mock_device, "temp_value")
+
+    assert wrapper
+    assert wrapper.color_temp_scale is ColorTempScale.MIRED


### PR DESCRIPTION
## Summary

Follow-up to #519. Adds `ColorTempScale`, so a light whose raw range is
linear in Kelvin can be handled as well as the mired-linear default.

- new `ColorTempScale` enum (`MIRED` / `KELVIN`) in `const.py`
- `ColorTempWrapper.color_temp_scale` class attribute, defaulting to
  `MIRED`
- the remap, `read_device_status` and `_convert_value_to_raw_value`
  branch on it; the mired path is untouched

Behaviour is unchanged for every existing device: nothing selects
`KELVIN` yet.

## Why

The Tuya cloud reports only the raw range of a color temperature
datapoint (typically 0-1000), never how that range maps onto Kelvin. We
assume it is linear in mireds, which is the better perceptual measure and
right for most lights, but some devices are linear in Kelvin instead. The
difference is not subtle: for a 1600-4000 K lamp, a raw value of 795
reads as 3059 K under mired scaling and 3508 K under Kelvin scaling.

This is internal to the wrapper — the host integration only ever sees
Kelvin, plus the `min_kelvin` / `max_kelvin` bounds added in #519 — so it
needs no change on the core side.

Step 3 of 4:

1. #519 — expose the range on the wrapper (merged)
2. core — read `min_kelvin` / `max_kelvin` for
   `_attr_min/max_color_temp_kelvin`
3. **this PR** — the mired/Kelvin scale choice
4. let a quirk select the values per datapoint, then the quirk itself for
   home-assistant/core#166103

## Tests

Kelvin-scale read and write across the full raw range, plus a test
pinning the default to `MIRED`. As in #519, subclassing is the only way
to select a non-default value at this point; wiring it to a quirk comes
next.