### PR TITLE
Add a real zndb fixture covering the hex-string electricity wrappers

### DIFF
--- a/tests/device_wrapper/__snapshots__/test_sensor.ambr
+++ b/tests/device_wrapper/__snapshots__/test_sensor.ambr
@@ -1,4 +1,14 @@
 # serializer version: 1
+# name: test_electricity_hex_string_wrappers_real_device
+  dict({
+    'ElectricityApparentPowerHexStringWrapper': 2350,
+    'ElectricityCurrentHexStringWrapper': 10000,
+    'ElectricityPowerFactorHexStringWrapper': 0.98,
+    'ElectricityPowerHexStringWrapper': 3000,
+    'ElectricityReactivePowerHexStringWrapper': 500,
+    'ElectricityVoltageHexStringWrapper': 230.5,
+  })
+# ---
 # name: test_electricity_json_wrappers_real_device
   dict({
     'ElectricityApparentPowerJsonWrapper': 2.35,

--- a/tests/device_wrapper/test_sensor.py
+++ b/tests/device_wrapper/test_sensor.py
@@ -490,3 +490,32 @@ def test_electricity_json_wrappers_real_device(
         states[wrapper_type.__name__] = wrapper.read_device_status(device)
 
     assert states == snapshot
+
+
+def test_electricity_hex_string_wrappers_real_device(
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the electricity hex-string wrappers against a real zndb meter.
+
+    `zndb_uqzhc4bx5zqwpg2m` is a multi-metering meter that reports its phase
+    datapoints as hex-encoded frame strings (`phase_s*`), so it is the
+    real-world check that the hex-string wrappers decode the frame the way
+    the meter reports it.
+    """
+    device = create_device("zndb_uqzhc4bx5zqwpg2m.json")
+    dpcode = "phase_s1"
+
+    states = {}
+    for wrapper_type in (
+        ElectricityCurrentHexStringWrapper,
+        ElectricityPowerHexStringWrapper,
+        ElectricityVoltageHexStringWrapper,
+        ElectricityReactivePowerHexStringWrapper,
+        ElectricityApparentPowerHexStringWrapper,
+        ElectricityPowerFactorHexStringWrapper,
+    ):
+        wrapper = wrapper_type.find_dpcode(device, dpcode)
+        assert wrapper
+        states[wrapper_type.__name__] = wrapper.read_device_status(device)
+
+    assert states == snapshot

--- a/tests/fixtures/devices/zndb_uqzhc4bx5zqwpg2m.json
+++ b/tests/fixtures/devices/zndb_uqzhc4bx5zqwpg2m.json
@@ -1,0 +1,74 @@
+{
+  "endpoint": "https://apigw.tuyacn.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "多路计量有线demo26082501",
+  "category": "zndb",
+  "product_id": "uqzhc4bx5zqwpg2m",
+  "product_name": "多路计量有线demo26082501",
+  "online": true,
+  "sub": false,
+  "time_zone": "+8:00",
+  "active_time": "2026-09-03T02:02:14+00:00",
+  "create_time": "2026-09-03T02:02:14+00:00",
+  "update_time": "2026-09-03T02:02:14+00:00",
+  "function": {
+    "event_clear": {
+      "code": "event_clear",
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "phase_s1": {
+      "type": "String",
+      "value": {}
+    },
+    "meter_id": {
+      "type": "String",
+      "value": {
+        "maxlen": 255
+      }
+    },
+    "imei_imsi": {
+      "type": "Json",
+      "value": {}
+    },
+    "supply_frequency": {
+      "type": "Integer",
+      "value": {
+        "unit": "Hz",
+        "min": 0,
+        "max": 9999,
+        "scale": 2,
+        "step": 1
+      }
+    },
+    "ct_ration": {
+      "type": "Raw",
+      "value": {}
+    },
+    "event_clear": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "online_state": {
+      "type": "Enum",
+      "value": {
+        "range": ["online", "offline"]
+      }
+    }
+  },
+  "status": {
+    "phase_s1": "020F0901002710000BB80001F400092E6200",
+    "meter_id": "",
+    "imei_imsi": "",
+    "supply_frequency": 0,
+    "ct_ration": "",
+    "event_clear": false,
+    "online_state": "online"
+  },
+  "set_up": false,
+  "support_local": true
+}


### PR DESCRIPTION
Follow-up to #524, adding the hex-string device fixture requested there.

`zndb_uqzhc4bx5zqwpg2m` is a multi-metering zndb meter that reports its phase datapoints as hex-encoded frame strings (`phase_s1`…`phase_s20`). That's a standard datapoint format already in use by customers on the Tuya side — this is part of exposing it to Home Assistant, so it's a real-world example rather than a test device.

The test decodes `phase_s1` through all six hex-string wrappers and snapshots the result, mirroring `test_electricity_raw_wrappers_real_device` and the JSON variant.
