### PR TITLE
Skip unsupported optional electricity sensors

### DIFF
--- a/src/tuya_device_handlers/definition/sensor.py
+++ b/src/tuya_device_handlers/definition/sensor.py
@@ -42,7 +42,9 @@ def get_default_definition(
     """Get DPCode wrapper for an entity description."""
     if wrapper_class:
         for cls in wrapper_class:
-            if wrapper := cls.find_dpcode(device, dpcode):
+            if (wrapper := cls.find_dpcode(device, dpcode)) and (
+                wrapper.is_supported(device)
+            ):
                 return SensorDefinition(sensor_wrapper=wrapper)
         return None
 

--- a/src/tuya_device_handlers/device_wrapper/base.py
+++ b/src/tuya_device_handlers/device_wrapper/base.py
@@ -24,6 +24,10 @@ class DeviceWrapper[T]:
         Override in subclasses to perform initialization logic.
         """
 
+    def is_supported(self, device: CustomerDevice) -> bool:
+        """Return whether the wrapper is supported by the device."""
+        return True
+
     def skip_update(
         self,
         device: CustomerDevice,

--- a/src/tuya_device_handlers/device_wrapper/sensor.py
+++ b/src/tuya_device_handlers/device_wrapper/sensor.py
@@ -132,9 +132,21 @@ class ElectricityVoltageJsonWrapper(DPCodeJsonWrapper[float]):
         return status.get("voltage")
 
 
-class ElectricityReactivePowerJsonWrapper(DPCodeJsonWrapper[float]):
+class _OptionalElectricityJsonWrapper(DPCodeJsonWrapper[float]):
+    """Base wrapper for optional electricity values in JSON."""
+
+    _JSON_KEY: str
+
+    def is_supported(self, device: CustomerDevice) -> bool:
+        """Return whether the JSON payload supports this value."""
+        status = self._read_dpcode_value(device)
+        return status is None or self._JSON_KEY in status
+
+
+class ElectricityReactivePowerJsonWrapper(_OptionalElectricityJsonWrapper):
     """Custom DPCode Wrapper for extracting reactive power from JSON."""
 
+    _JSON_KEY = "reactivePower"
     native_unit = "kvar"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
@@ -144,9 +156,10 @@ class ElectricityReactivePowerJsonWrapper(DPCodeJsonWrapper[float]):
         return status.get("reactivePower")
 
 
-class ElectricityApparentPowerJsonWrapper(DPCodeJsonWrapper[float]):
+class ElectricityApparentPowerJsonWrapper(_OptionalElectricityJsonWrapper):
     """Custom DPCode Wrapper for extracting apparent power from JSON."""
 
+    _JSON_KEY = "apparentPower"
     native_unit = "kVA"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
@@ -156,8 +169,10 @@ class ElectricityApparentPowerJsonWrapper(DPCodeJsonWrapper[float]):
         return status.get("apparentPower")
 
 
-class ElectricityPowerFactorJsonWrapper(DPCodeJsonWrapper[float]):
+class ElectricityPowerFactorJsonWrapper(_OptionalElectricityJsonWrapper):
     """Custom DPCode Wrapper for extracting power factor from JSON."""
+
+    _JSON_KEY = "powerFactor"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
@@ -210,9 +225,26 @@ class ElectricityVoltageRawWrapper(DPCodeRawWrapper[float]):
         return value.voltage
 
 
-class ElectricityReactivePowerRawWrapper(DPCodeRawWrapper[float]):
+class _OptionalElectricityRawWrapper(DPCodeRawWrapper[float]):
+    """Base wrapper for optional electricity values in RAW data."""
+
+    _ATTRIBUTE: str
+
+    def is_supported(self, device: CustomerDevice) -> bool:
+        """Return whether the RAW payload supports this value."""
+        raw_value = self._read_dpcode_value(device)
+        if (
+            raw_value is None
+            or (value := ElectricityData.from_bytes(raw_value)) is None
+        ):
+            return True
+        return getattr(value, self._ATTRIBUTE) is not None
+
+
+class ElectricityReactivePowerRawWrapper(_OptionalElectricityRawWrapper):
     """Custom DPCode Wrapper for extracting reactive power from base64."""
 
+    _ATTRIBUTE = "reactive_power"
     native_unit = "var"
     suggested_unit = "kvar"
 
@@ -225,9 +257,10 @@ class ElectricityReactivePowerRawWrapper(DPCodeRawWrapper[float]):
         return value.reactive_power
 
 
-class ElectricityApparentPowerRawWrapper(DPCodeRawWrapper[float]):
+class ElectricityApparentPowerRawWrapper(_OptionalElectricityRawWrapper):
     """Custom DPCode Wrapper for extracting apparent power from base64."""
 
+    _ATTRIBUTE = "apparent_power"
     native_unit = "VA"
     suggested_unit = "kVA"
 
@@ -240,8 +273,10 @@ class ElectricityApparentPowerRawWrapper(DPCodeRawWrapper[float]):
         return value.apparent_power
 
 
-class ElectricityPowerFactorRawWrapper(DPCodeRawWrapper[float]):
+class ElectricityPowerFactorRawWrapper(_OptionalElectricityRawWrapper):
     """Custom DPCode Wrapper for extracting power factor from base64."""
+
+    _ATTRIBUTE = "power_factor"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""
@@ -296,9 +331,28 @@ class ElectricityVoltageHexStringWrapper(DPCodeStringWrapper[float]):
         return value.voltage
 
 
-class ElectricityReactivePowerHexStringWrapper(DPCodeStringWrapper[float]):
+class _OptionalElectricityHexStringWrapper(DPCodeStringWrapper[float]):
+    """Base wrapper for optional electricity values in hex strings."""
+
+    _ATTRIBUTE: str
+
+    def is_supported(self, device: CustomerDevice) -> bool:
+        """Return whether the hex-string payload supports this value."""
+        raw_value = self._read_dpcode_value(device)
+        if (
+            raw_value is None
+            or (value := ElectricityData.from_hex(raw_value)) is None
+        ):
+            return True
+        return getattr(value, self._ATTRIBUTE) is not None
+
+
+class ElectricityReactivePowerHexStringWrapper(
+    _OptionalElectricityHexStringWrapper
+):
     """Custom DPCode Wrapper for extracting reactive power from a hex string."""
 
+    _ATTRIBUTE = "reactive_power"
     native_unit = "var"
     suggested_unit = "kvar"
 
@@ -311,9 +365,12 @@ class ElectricityReactivePowerHexStringWrapper(DPCodeStringWrapper[float]):
         return value.reactive_power
 
 
-class ElectricityApparentPowerHexStringWrapper(DPCodeStringWrapper[float]):
+class ElectricityApparentPowerHexStringWrapper(
+    _OptionalElectricityHexStringWrapper
+):
     """Custom DPCode Wrapper for extracting apparent power from a hex string."""
 
+    _ATTRIBUTE = "apparent_power"
     native_unit = "VA"
     suggested_unit = "kVA"
 
@@ -326,8 +383,12 @@ class ElectricityApparentPowerHexStringWrapper(DPCodeStringWrapper[float]):
         return value.apparent_power
 
 
-class ElectricityPowerFactorHexStringWrapper(DPCodeStringWrapper[float]):
+class ElectricityPowerFactorHexStringWrapper(
+    _OptionalElectricityHexStringWrapper
+):
     """Custom DPCode Wrapper for extracting power factor from a hex string."""
+
+    _ATTRIBUTE = "power_factor"
 
     def read_device_status(self, device: CustomerDevice) -> float | None:
         """Read the device value for the dpcode."""

--- a/tests/definition/test_sensor.py
+++ b/tests/definition/test_sensor.py
@@ -7,8 +7,20 @@ from tuya_device_handlers.definition.sensor import get_default_definition
 from tuya_device_handlers.device_wrapper.common import (
     DPCodeEnumWrapper,
     DPCodeIntegerWrapper,
+    DPCodeTypeInformationWrapper,
 )
-from tuya_device_handlers.device_wrapper.sensor import DeltaIntegerWrapper
+from tuya_device_handlers.device_wrapper.sensor import (
+    DeltaIntegerWrapper,
+    ElectricityApparentPowerHexStringWrapper,
+    ElectricityApparentPowerJsonWrapper,
+    ElectricityApparentPowerRawWrapper,
+    ElectricityPowerFactorHexStringWrapper,
+    ElectricityPowerFactorJsonWrapper,
+    ElectricityPowerFactorRawWrapper,
+    ElectricityReactivePowerHexStringWrapper,
+    ElectricityReactivePowerJsonWrapper,
+    ElectricityReactivePowerRawWrapper,
+)
 
 
 @pytest.mark.parametrize(
@@ -61,3 +73,113 @@ def test_get_default_definition_fails(
     """Test get_default_definition."""
     device = create_device("cs_zibqa9dutqyaxym2.json")
     assert not get_default_definition(device, "bad", lookup_type)  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.parametrize(
+    ("fixture_filename", "dpcode", "wrapper_type"),
+    [
+        (
+            "dlq_cnpkf4xdmd9v49iq.json",
+            "phase_a",
+            ElectricityReactivePowerRawWrapper,
+        ),
+        (
+            "dlq_cnpkf4xdmd9v49iq.json",
+            "phase_a",
+            ElectricityApparentPowerRawWrapper,
+        ),
+        (
+            "dlq_cnpkf4xdmd9v49iq.json",
+            "phase_a",
+            ElectricityPowerFactorRawWrapper,
+        ),
+        (
+            "zndb_iow5ux77dxy3yrpj.json",
+            "phase_a",
+            ElectricityReactivePowerJsonWrapper,
+        ),
+        (
+            "zndb_iow5ux77dxy3yrpj.json",
+            "phase_a",
+            ElectricityApparentPowerJsonWrapper,
+        ),
+        (
+            "zndb_iow5ux77dxy3yrpj.json",
+            "phase_a",
+            ElectricityPowerFactorJsonWrapper,
+        ),
+        (
+            "zndb_uqzhc4bx5zqwpg2m.json",
+            "phase_s1",
+            ElectricityReactivePowerHexStringWrapper,
+        ),
+        (
+            "zndb_uqzhc4bx5zqwpg2m.json",
+            "phase_s1",
+            ElectricityApparentPowerHexStringWrapper,
+        ),
+        (
+            "zndb_uqzhc4bx5zqwpg2m.json",
+            "phase_s1",
+            ElectricityPowerFactorHexStringWrapper,
+        ),
+    ],
+)
+def test_get_optional_electricity_definition_supported(
+    fixture_filename: str,
+    dpcode: str,
+    wrapper_type: type[DPCodeTypeInformationWrapper],
+) -> None:
+    """Test optional electricity definitions with real device payloads."""
+    device = create_device(fixture_filename)
+
+    assert get_default_definition(device, dpcode, (wrapper_type,))
+
+
+@pytest.mark.parametrize(
+    "wrapper_type",
+    [
+        ElectricityReactivePowerRawWrapper,
+        ElectricityApparentPowerRawWrapper,
+        ElectricityPowerFactorRawWrapper,
+    ],
+)
+def test_get_optional_electricity_definition_unsupported(
+    wrapper_type: type[DPCodeTypeInformationWrapper],
+) -> None:
+    """Test optional definitions are omitted for a real legacy RAW frame."""
+    device = create_device("zndb_ze8faryrxr0glqnn.json")
+
+    assert not get_default_definition(device, "phase_a", (wrapper_type,))
+
+
+@pytest.mark.parametrize(
+    ("fixture_filename", "dpcode", "wrapper_type"),
+    [
+        (
+            "zndb_ze8faryrxr0glqnn.json",
+            "phase_a",
+            ElectricityReactivePowerRawWrapper,
+        ),
+        (
+            "zndb_iow5ux77dxy3yrpj.json",
+            "phase_a",
+            ElectricityReactivePowerJsonWrapper,
+        ),
+        (
+            "zndb_uqzhc4bx5zqwpg2m.json",
+            "phase_s1",
+            ElectricityReactivePowerHexStringWrapper,
+        ),
+    ],
+)
+def test_get_optional_electricity_definition_with_unknown_status(
+    fixture_filename: str,
+    dpcode: str,
+    wrapper_type: type[DPCodeTypeInformationWrapper],
+) -> None:
+    """Test missing startup status does not hide optional definitions."""
+    device = create_device(fixture_filename)
+    device.status.pop(dpcode)
+
+    assert get_default_definition(device, dpcode, (wrapper_type,))

--- a/tests/device_wrapper/__snapshots__/test_sensor.ambr
+++ b/tests/device_wrapper/__snapshots__/test_sensor.ambr
@@ -11,12 +11,12 @@
 # ---
 # name: test_electricity_json_wrappers_real_device
   dict({
-    'ElectricityApparentPowerJsonWrapper': 2.35,
-    'ElectricityCurrentJsonWrapper': 10.0,
-    'ElectricityPowerFactorJsonWrapper': 0.98,
-    'ElectricityPowerJsonWrapper': 3.0,
-    'ElectricityReactivePowerJsonWrapper': 0.5,
-    'ElectricityVoltageJsonWrapper': 230.5,
+    'ElectricityApparentPowerJsonWrapper': 0.0,
+    'ElectricityCurrentJsonWrapper': 53.86,
+    'ElectricityPowerFactorJsonWrapper': 0.77,
+    'ElectricityPowerJsonWrapper': 9.548,
+    'ElectricityReactivePowerJsonWrapper': 0.0,
+    'ElectricityVoltageJsonWrapper': 230.1,
   })
 # ---
 # name: test_electricity_raw_wrappers_real_device

--- a/tests/fixtures/devices/zndb_iow5ux77dxy3yrpj.json
+++ b/tests/fixtures/devices/zndb_iow5ux77dxy3yrpj.json
@@ -96,28 +96,28 @@
     "forward_energy_total": 0,
     "reverse_energy_total": 0,
     "phase_a": {
-      "voltage": 230.5,
-      "electricCurrent": 10.0,
-      "power": 3.0,
-      "reactivePower": 0.5,
-      "apparentPower": 2.35,
-      "powerFactor": 0.98
+      "voltage": 230.1,
+      "electricCurrent": 53.86,
+      "power": 9.548,
+      "reactivePower": 0.0,
+      "apparentPower": 0.0,
+      "powerFactor": 0.77
     },
     "phase_b": {
-      "voltage": 231.2,
-      "electricCurrent": 8.5,
-      "power": 1.9,
-      "reactivePower": 0.42,
-      "apparentPower": 1.94,
-      "powerFactor": 0.97
+      "voltage": 231.8,
+      "electricCurrent": 49.202,
+      "power": 9.51,
+      "reactivePower": 0.0,
+      "apparentPower": 0.0,
+      "powerFactor": 0.83
     },
     "phase_c": {
       "voltage": 229.6,
-      "electricCurrent": 12.3,
-      "power": 2.75,
-      "reactivePower": -0.61,
-      "apparentPower": 2.81,
-      "powerFactor": 0.98
+      "electricCurrent": 50.914,
+      "power": 10.006,
+      "reactivePower": 0.0,
+      "apparentPower": 0.0,
+      "powerFactor": 0.86
     },
     "power_total": -99999999,
     "fault": 0,

--- a/tests/fixtures/devices/zndb_ze8faryrxr0glqnn.json
+++ b/tests/fixtures/devices/zndb_ze8faryrxr0glqnn.json
@@ -1,0 +1,77 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Meter",
+  "category": "zndb",
+  "product_id": "ze8faryrxr0glqnn",
+  "product_name": "PJ2101A 1P WiFi Smart Meter ",
+  "online": true,
+  "sub": false,
+  "time_zone": "+02:00",
+  "active_time": "2024-08-24T11:22:33+00:00",
+  "create_time": "2024-08-24T11:22:33+00:00",
+  "update_time": "2024-08-24T11:22:33+00:00",
+  "function": {
+    "forward_energy_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 0,
+        "max": 99999999,
+        "scale": 2,
+        "step": 1
+      }
+    },
+    "energy_month": {
+      "type": "raw",
+      "value": {}
+    },
+    "energy_daily": {
+      "type": "raw",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "energy_month": {
+      "type": "raw",
+      "value": {}
+    },
+    "energy_daily": {
+      "type": "raw",
+      "value": {}
+    },
+    "phase_a": {
+      "type": "raw",
+      "value": {}
+    },
+    "forward_energy_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 0,
+        "max": 99999999,
+        "scale": 2,
+        "step": 1
+      }
+    },
+    "reverse_energy_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 0,
+        "max": 99999999,
+        "scale": 2,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "energy_month": "GAkYCQAAANQ=",
+    "energy_daily": "",
+    "phase_a": "CSIAFfQABKE="
+  },
+  "set_up": true,
+  "support_local": false
+}


### PR DESCRIPTION
## Summary

- let device wrappers report whether a sensor value is supported by the current device payload
- omit reactive power, apparent power, and power factor definitions when a parsed payload definitively lacks those values
- keep definitions when startup status is missing or temporarily invalid, avoiding permanent entity loss from a transient state
- sync the JSON electricity fixture with the real device data already used in Home Assistant Core and add the real legacy RAW fixture

This provides the library-side handling requested for https://github.com/home-assistant/core/pull/181549.

## Test plan

- `poetry run pytest --cov tuya_device_handlers tests` (581 passed, 98.37% coverage)
- `poetry run ty check src tests`
- `poetry run ruff check .`
- `poetry run ruff format --check .`
- `poetry run pylint src/tuya_device_handlers`

## Related issue

Related to https://github.com/home-assistant/core/pull/181549
