### PR TITLE
Add quirk for InverFlow / Aquagem inverter pool pump (ircs2n82vgrozoew)

### DIFF
--- a/src/tuya_device_handlers/devices/hwsb/__init__.py
+++ b/src/tuya_device_handlers/devices/hwsb/__init__.py
@@ -1,0 +1,4 @@
+"""Quirks for Tuya HWSB category (outdoor equipment).
+
+https://developer.tuya.com/en/docs/iot/categoryhwsb?id=Kaiuz08zj1l4y
+"""

--- a/src/tuya_device_handlers/devices/hwsb/hwsb_ircs2n82vgrozoew.py
+++ b/src/tuya_device_handlers/devices/hwsb/hwsb_ircs2n82vgrozoew.py
@@ -1,0 +1,91 @@
+"""Quirk for InverFlow / Aquagem Inverter Pool Pump (ircs2n82vgrozoew).
+
+The Tuya OpenAPI cloud schema for category 'hwsb' (Outdoor Equipment) only
+exposes DP 5 (cur_power) under standard functions, leaving control datapoints
+unmapped in Home Assistant. This quirk defines the missing switch, mode,
+speed, flow rate, and energy datapoints.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(
+        product_id="ircs2n82vgrozoew",
+        manufacturer="Aquagem",
+        model="InverFlow Inverter Pool Pump",
+        model_id="InverFlow",
+    )
+    # DP 105: Pump running / power switch
+    .add_dpid_boolean(
+        dpid=105,
+        dpcode="switch",
+        dpmode=DPMode.READ | DPMode.WRITE,
+    )
+    # DP 103: Operational mode
+    .add_dpid_enum(
+        dpid=103,
+        dpcode="mode",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        enum_range=["MI", "AI", "backwash"],
+    )
+    # DP 111: Manual target power / speed percentage
+    .add_dpid_integer(
+        dpid=111,
+        dpcode="speed_set",
+        dpmode=DPMode.READ | DPMode.WRITE,
+        unit="%",
+        min=30,
+        max=120,
+        scale=0,
+        step=5,
+    )
+    # DP 102: Actual reported motor speed percentage
+    .add_dpid_integer(
+        dpid=102,
+        dpcode="speed_current",
+        dpmode=DPMode.READ,
+        unit="%",
+        min=30,
+        max=120,
+        scale=0,
+        step=1,
+    )
+    # DP 5: Real-time electrical power consumption
+    .add_dpid_integer(
+        dpid=5,
+        dpcode="cur_power",
+        dpmode=DPMode.READ,
+        unit="W",
+        min=0,
+        max=3000,
+        scale=0,
+        step=1,
+    )
+    # DP 112: Real-time volume flow rate
+    .add_dpid_integer(
+        dpid=112,
+        dpcode="flow_rate",
+        dpmode=DPMode.READ,
+        unit="gpm",
+        min=0,
+        max=1000,
+        scale=0,
+        step=1,
+    )
+    # DP 109: Cumulative energy consumption
+    .add_dpid_integer(
+        dpid=109,
+        dpcode="add_ele",
+        dpmode=DPMode.READ,
+        unit="kWh",
+        min=0,
+        max=999999,
+        scale=2,
+        step=1,
+        report_type="sum",
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/hwsb/__init__.py
+++ b/tests/devices/hwsb/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tuya HWSB category quirks."""

--- a/tests/devices/hwsb/test_hwsb_ircs2n82vgrozoew.py
+++ b/tests/devices/hwsb/test_hwsb_ircs2n82vgrozoew.py
@@ -1,0 +1,22 @@
+"""Test device-level quirk initialisation for InverFlow pool pump."""
+
+from tests import create_device
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_inverflow_pool_pump_quirk(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Test that quirk adds missing control and telemetry datapoints."""
+    device = create_device("hwsb_ircs2n82vgrozoew.json")
+
+    assert "switch" not in device.function
+    assert "mode" not in device.function
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert "switch" in device.function
+    assert "mode" in device.function
+    assert "speed_set" in device.function
+    assert "flow_rate" in device.status_range
+    assert "add_ele" in device.status_range

--- a/tests/fixtures/devices/hwsb_ircs2n82vgrozoew.json
+++ b/tests/fixtures/devices/hwsb_ircs2n82vgrozoew.json
@@ -1,0 +1,40 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Pool Pump",
+  "category": "hwsb",
+  "product_id": "ircs2n82vgrozoew",
+  "product_name": "InverFlow",
+  "online": true,
+  "sub": false,
+  "time_zone": "-04:00",
+  "active_time": 1788641646,
+  "create_time": 1788641646,
+  "update_time": 1788641646,
+  "function": {},
+  "local_strategy": {
+    "5": {
+      "value_convert": "default",
+      "status_code": "cur_power",
+      "config_item": {
+        "statusFormat": "{\"cur_power\":\"$\"}",
+        "valueDesc": "{\"unit\":\"W\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
+        "valueType": "Integer",
+        "enumMappingMap": {},
+        "pid": "ircs2n82vgrozoew"
+      }
+    }
+  },
+  "status_range": {
+    "cur_power": {
+      "type": "Integer",
+      "value": "{\"unit\":\"W\",\"min\":0,\"max\":3000,\"scale\":0,\"step\":1}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "cur_power": 350
+  }
+}


### PR DESCRIPTION
## Summary
Adds a device quirk for the InverFlow / Aquagem inverter pool pump (Product ID `ircs2n82vgrozoew`, Tuya category `hwsb`).

Currently, Tuya Cloud OpenAPI returns an empty standard `function` map for this category, only exposing DP 5 (`cur_power`). As a result, the device is flagged as unsupported in Home Assistant. This quirk adds DP definitions for:
- DP 105: Pump power switch (`switch`)
- DP 103: Operating mode (`mode`: MI, AI, backwash)
- DP 111: Target power/speed setting (`speed_set`: 30–120%)
- DP 102: Reported motor speed (`speed_current`: 30–120%)
- DP 5: Real-time power (`cur_power`: 0–3000 W)
- DP 112: Water flow rate (`flow_rate`: gpm)
- DP 109: Cumulative energy (`add_ele`: kWh, scale 2)

## Test plan
1. Added device diagnostic fixture `tests/fixtures/devices/hwsb_ircs2n82vgrozoew.json`.
2. Added quirk unit test `tests/devices/hwsb/test_hwsb_ircs2n82vgrozoew.py`.
3. Verified DP mappings match live device interrogation via local Tuya protocol 3.3.

## Related issue
None
