### PR TITLE
Add quirk for Tuya contact sensor 001D02T1-3S (a9fn0xcsckjoqpnd)

### DIFF
--- a/src/tuya_device_handlers/devices/tdq/tdq_a9fn0xcsckjoqpnd.py
+++ b/src/tuya_device_handlers/devices/tdq/tdq_a9fn0xcsckjoqpnd.py
@@ -1,0 +1,37 @@
+"""Quirk for Contact sensor 001D02T1-3S (product_id a9fn0xcsckjoqpnd).
+
+Tuya declares this door sensor under the wrong category ('tdq' = breaker,
+instead of 'mcs' = door/window sensor) and advertises no datapoints at all:
+function, status_range and local_strategy all arrive empty, so Home Assistant
+cannot build any entity for it.
+
+The device does report over MQTT:
+  DP 101 -> doorcontact_state (bool)
+  DP 102 -> battery_state (enum low/middle/high)
+
+Reported upstream in home-assistant/core#159399.
+Mirrors devices/tdq/tdq_p6sqiuesvhmhvv4f.py, which fixes the identical
+defect on a sibling contact sensor.
+"""
+
+from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
+from tuya_device_handlers.builder import DeviceQuirk
+from tuya_device_handlers.const import DPMode
+
+(
+    DeviceQuirk()
+    .applies_to(product_id="a9fn0xcsckjoqpnd")
+    .override_category("mcs")
+    .add_dpid_boolean(
+        dpid=101,
+        dpcode="doorcontact_state",
+        dpmode=DPMode.READ,
+    )
+    .add_dpid_enum(
+        dpid=102,
+        dpcode="battery_state",
+        dpmode=DPMode.READ,
+        enum_range=["low", "middle", "high"],
+    )
+    .register(TUYA_QUIRKS_REGISTRY)
+)

--- a/tests/devices/tdq/test_a9fn0xcsckjoqpnd.py
+++ b/tests/devices/tdq/test_a9fn0xcsckjoqpnd.py
@@ -1,0 +1,67 @@
+"""Test device-level quirk initialisation."""
+
+from tuya_sharing import Manager
+
+from tests import create_device
+from tests.integration_helpers.binary_sensor import (
+    get_binary_sensor_default_definitions,
+)
+from tests.integration_helpers.sensor import get_sensor_default_definitions
+from tuya_device_handlers.registry import QuirksRegistry
+
+
+def test_quirk_overrides(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Quirk overrides the category and registers the contact datapoints."""
+    device = create_device("tdq_a9fn0xcsckjoqpnd.json")
+    assert device.category == "tdq"
+    assert "doorcontact_state" not in device.status_range
+    assert "battery_state" not in device.status_range
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert device.category == "mcs"
+    assert "doorcontact_state" in device.status_range
+    assert "battery_state" in device.status_range
+
+
+def test_default_definitions(
+    filled_quirks_registry: QuirksRegistry,
+) -> None:
+    """Quirk exposes the contact binary sensor and the battery sensor."""
+    device = create_device("tdq_a9fn0xcsckjoqpnd.json")
+    assert "doorcontact_state" not in get_binary_sensor_default_definitions(
+        device
+    )
+    assert "battery_state" not in get_sensor_default_definitions(device)
+
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert "doorcontact_state" in get_binary_sensor_default_definitions(device)
+    assert "battery_state" in get_sensor_default_definitions(device)
+
+
+def test_mqtt(
+    filled_quirks_registry: QuirksRegistry, mock_manager: Manager
+) -> None:
+    """Check local strategy handling."""
+    device = create_device("tdq_a9fn0xcsckjoqpnd.json")
+    mock_manager.device_map[device.id] = device
+    filled_quirks_registry.initialise_device_quirk(device)
+
+    assert device.category == "mcs"
+    assert "doorcontact_state" not in device.status
+
+    # Trigger mqtt updates
+    mock_manager._on_device_report(
+        device.id,
+        [{"dpId": 101, "t": 1757721600000, "value": False}],
+    )
+    assert device.status["doorcontact_state"] is False
+
+    mock_manager._on_device_report(
+        device.id,
+        [{"dpId": 101, "t": 1757721600000, "value": True}],
+    )
+    assert device.status["doorcontact_state"] is True

--- a/tests/fixtures/devices/tdq_a9fn0xcsckjoqpnd.json
+++ b/tests/fixtures/devices/tdq_a9fn0xcsckjoqpnd.json
@@ -1,0 +1,22 @@
+{
+  "endpoint": "https://apigw.tuyaus.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "a9fn0xcsckjoqpnd",
+  "category": "tdq",
+  "product_id": "a9fn0xcsckjoqpnd",
+  "product_name": "Contact Sensor",
+  "online": true,
+  "sub": false,
+  "time_zone": "-05:00",
+  "active_time": "2026-09-12T15:45:03+00:00",
+  "create_time": "2026-09-12T15:45:03+00:00",
+  "update_time": "2026-09-12T15:45:03+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "local_strategy": {},
+  "set_up": false,
+  "support_local": true
+}


### PR DESCRIPTION
## Summary

Adds a quirk for the Tuya contact sensor `001D02T1-3S`
(`product_id: a9fn0xcsckjoqpnd`).

Tuya declares this device under category `tdq` (breaker) instead of `mcs`
(door/window sensor) and advertises no datapoints at all: `function`,
`status_range` and `local_strategy` all arrive empty, so Home Assistant
creates no entities for it.

The device does report over MQTT:

- DP 101 -> `doorcontact_state` (Boolean)
- DP 102 -> `battery_state` (Enum: low / middle / high)

This mirrors the existing quirk for the sibling device
`tdq_p6sqiuesvhmhvv4f`, which fixes the identical defect.

## Test plan

Adds `tests/devices/tdq/test_a9fn0xcsckjoqpnd.py` covering category
override, default entity definitions, and MQTT handling of dpId 101.

Also verified on real hardware: Home Assistant Core 2026.9.0 (Container),
two physical sensors of this product_id. After dropping the quirk in
`<config>/tuya_quirks/` and restarting Home Assistant:

- `binary_sensor.<device>_door` and `sensor.<device>_battery_state` are
  created
- Device diagnostics report `original_category: "tdq"` with
  `category: "mcs"`, and DP 101/102 present in `local_strategy`
- Open/close transitions are recorded in history in real time via MQTT push

Note: reloading the Tuya integration was not enough for the entities to
appear; a full Home Assistant restart was required.

## Related issue

Reported upstream in home-assistant/core#159399.
